### PR TITLE
Respect property value scope preferences in resource cover display

### DIFF
--- a/src/modules/Bakabase.Modules.Property/Resources/PropertyResource.resx
+++ b/src/modules/Bakabase.Modules.Property/Resources/PropertyResource.resx
@@ -147,6 +147,9 @@
   <data name="BuiltinPropertyName_Rating" xml:space="preserve">
     <value>Rating</value>
   </data>
+  <data name="BuiltinPropertyName_Name" xml:space="preserve">
+    <value>Name</value>
+  </data>
   <data name="BuiltinPropertyName_CustomProperty" xml:space="preserve">
     <value>Custom property</value>
   </data>

--- a/src/modules/Bakabase.Modules.Property/Resources/PropertyResource.zh-Hans.resx
+++ b/src/modules/Bakabase.Modules.Property/Resources/PropertyResource.zh-Hans.resx
@@ -147,6 +147,9 @@
   <data name="BuiltinPropertyName_Rating" xml:space="preserve">
     <value>评分</value>
   </data>
+  <data name="BuiltinPropertyName_Name" xml:space="preserve">
+    <value>名称</value>
+  </data>
   <data name="BuiltinPropertyName_CustomProperty" xml:space="preserve">
     <value>自定义属性</value>
   </data>

--- a/src/web/src/components/Resource/index.tsx
+++ b/src/web/src/components/Resource/index.tsx
@@ -3,10 +3,10 @@
 import type { CSSProperties } from "react";
 import type { IResourceCoverRef } from "@/components/Resource/components/ResourceCover";
 import type SimpleSearchEngine from "@/core/models/SimpleSearchEngine";
-import type { Property, Resource as ResourceModel } from "@/core/models/Resource";
+import type { Property, Resource as ResourceModel, PropertyValueScopePreference } from "@/core/models/Resource";
 import type { TagValue } from "@/components/StandardValue/models";
 
-import React, { useCallback, useImperativeHandle, useReducer, useRef, useState } from "react";
+import React, { useCallback, useImperativeHandle, useMemo, useReducer, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   ApartmentOutlined,
@@ -42,6 +42,8 @@ import {
   DataOrigin,
   PropertyPool,
   PropertyType,
+  PropertyValueScope,
+  propertyValueScopes,
   ResourceAdditionalItem,
   ResourceProperty,
   ResourceSource,
@@ -50,7 +52,7 @@ import {
   ResourceTag,
   StandardValueType,
 } from "@/sdk/constants";
-import { useUiOptionsStore } from "@/stores/options";
+import { useResourceOptionsStore, useUiOptionsStore } from "@/stores/options";
 import PlayControl from "@/components/Resource/components/PlayControl";
 import type { PlayControlPortalProps, PlayControlRef, FsDiscoveryStatus } from "@/components/Resource/components/PlayControl";
 import ContextMenuItems from "@/components/Resource/components/ContextMenuItems";
@@ -71,6 +73,37 @@ const renderSourceIcon = (origin: DataOrigin, className: string): React.ReactNod
     default:
       return <PlayCircleOutlined className={className} />;
   }
+};
+
+// Mirrors DetailModal's PropertyContainer value selection so cover and modal stay consistent.
+const selectValueByScopePriority = (
+  values: Property["values"],
+  globalScopePriority: PropertyValueScope[],
+  preference?: PropertyValueScopePreference,
+): NonNullable<Property["values"]>[number] | undefined => {
+  let effectivePriority = globalScopePriority;
+
+  if (preference?.priorities && preference.priorities.length > 0) {
+    const chain: PropertyValueScope[] = [];
+
+    for (const p of preference.priorities) {
+      chain.push(p.scope);
+      if (!p.fallbackOnEmpty) {
+        break;
+      }
+    }
+    effectivePriority = chain;
+  }
+
+  for (const scope of effectivePriority) {
+    const value = values?.find((v) => v.scope == scope);
+
+    if (value && (value.aliasAppliedBizValue ?? value.bizValue)) {
+      return value;
+    }
+  }
+
+  return undefined;
 };
 
 type MenuEntry = {
@@ -291,6 +324,37 @@ const Resource = React.forwardRef((props: Props, ref) => {
   renderedTimes.current += 1;
 
   const uiOptions = useUiOptionsStore((state) => state.data);
+  const resourceOptions = useResourceOptionsStore((state) => state.data);
+
+  const valueScopePriority = useMemo<PropertyValueScope[]>(() => {
+    const configured = resourceOptions.propertyValueScopePriority;
+    const vsp =
+      configured && configured.length > 0
+        ? configured.slice()
+        : propertyValueScopes.map((s) => s.value);
+
+    for (const scope of propertyValueScopes) {
+      if (!vsp.includes(scope.value)) {
+        if (scope.value == PropertyValueScope.Manual) {
+          vsp.splice(0, 0, scope.value);
+        } else {
+          vsp.push(scope.value);
+        }
+      }
+    }
+
+    return vsp;
+  }, [resourceOptions.propertyValueScopePriority]);
+
+  const scopePreferenceMap = useMemo(() => {
+    const map = new Map<string, PropertyValueScopePreference>();
+
+    for (const p of resource.scopePreferences ?? []) {
+      map.set(`${p.propertyPool}-${p.propertyId}`, p);
+    }
+
+    return map;
+  }, [resource.scopePreferences]);
 
   // Use useReducer for stable forceUpdate reference
   const [, forceUpdate] = useReducer(x => x + 1, 0);
@@ -538,14 +602,24 @@ const Resource = React.forwardRef((props: Props, ref) => {
                     }
                     break;
                   case PropertyPool.Reserved:
-                  case PropertyPool.Custom:
+                  case PropertyPool.Custom: {
                     const property = resource.properties?.[dpk.pool as PropertyPool]?.[dpk.id];
+                    const selectedValue = selectValueByScopePriority(
+                      property?.values,
+                      valueScopePriority,
+                      scopePreferenceMap.get(`${dpk.pool}-${dpk.id}`),
+                    );
+                    const rawBizValue =
+                      selectedValue?.aliasAppliedBizValue ?? selectedValue?.bizValue;
 
-                    const rawBizValue = property?.values?.find((x) => x.bizValue)?.bizValue;
                     bizValueType = property?.bizValueType;
                     propertyType = property?.type;
-                    bizValue = bizValueType != undefined ? convertFromApiValue(rawBizValue, bizValueType) : rawBizValue;
+                    bizValue =
+                      bizValueType != undefined
+                        ? convertFromApiValue(rawBizValue, bizValueType)
+                        : rawBizValue;
                     break;
+                  }
                 }
               } catch (error) {
                 log("error occurred while rendering display property", error);
@@ -611,21 +685,23 @@ const Resource = React.forwardRef((props: Props, ref) => {
       const p: Property = customPropertyValues[id];
 
       if (p.bizValueType == StandardValueType.ListTag) {
-        const values = p.values?.find((v) => (v.aliasAppliedBizValue as TagValue[])?.length > 0);
+        const selectedValue = selectValueByScopePriority(
+          p.values,
+          valueScopePriority,
+          scopePreferenceMap.get(`${PropertyPool.Custom}-${id}`),
+        );
+        const tags = (selectedValue?.aliasAppliedBizValue ??
+          selectedValue?.bizValue) as TagValue[] | undefined;
 
         if (
-          values &&
+          tags &&
+          tags.length > 0 &&
           displayPropertyKeys.some((dpk) => dpk.pool == PropertyPool.Custom && dpk.id == id)
         ) {
-          firstTagsValue = (values.aliasAppliedBizValue as TagValue[]).map((id, i) => {
-            const bvs = values.aliasAppliedBizValue as TagValue[];
-            const bv = bvs?.[i];
-
-            return {
-              value: id,
-              ...bv,
-            };
-          });
+          firstTagsValue = tags.map((tag) => ({
+            value: tag,
+            ...tag,
+          }));
           firstTagsValuePropertyId = id;
 
           return true;


### PR DESCRIPTION
## Summary
Aligns the resource cover display with the DetailModal by respecting property value scope preferences when selecting which value to show for a property. This ensures consistency between the cover preview and the detailed view.

## Key Changes
- Added `selectValueByScopePriority()` utility function that mirrors DetailModal's PropertyContainer value selection logic, prioritizing values based on global scope priority and per-property preferences
- Integrated resource options store to access configured `propertyValueScopePriority` settings
- Updated property value selection in display properties rendering to use scope-aware selection instead of simple first-match
- Updated tag value selection for ListTag properties to use the same scope-aware logic
- Added `PropertyValueScopePreference` type import and created `scopePreferenceMap` for efficient preference lookup
- Added localization entries for "Name" property in English and Chinese resource files

## Implementation Details
- The `valueScopePriority` is computed once via `useMemo` from configured options, with fallback to all available scopes and Manual scope prioritized first
- `scopePreferenceMap` is built from `resource.scopePreferences` for O(1) lookup during rendering
- Value selection now respects both global priority and per-property fallback behavior (via `fallbackOnEmpty` flag)
- Refactored tag value mapping logic to be clearer and more maintainable

https://claude.ai/code/session_01PMLSLjjjmqVbUkh3iamVcH