### PR TITLE
fix(sentry): 修复 Sentry 上报的 4 个生产崩溃

### DIFF
--- a/src/apps/Bakabase.Service/Controllers/FileController.cs
+++ b/src/apps/Bakabase.Service/Controllers/FileController.cs
@@ -42,6 +42,7 @@ using Bootstrap.Models.Constants;
 using Bootstrap.Models.ResponseModels;
 using CliWrap;
 using CliWrap.Buffered;
+using CliWrap.Exceptions;
 using DotNext.Collections.Generic;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -1443,38 +1444,37 @@ namespace Bakabase.Service.Controllers
                                 .RequestAborted);
                         var preferredCodec = hwAccelInfo.PreferredCodec;
 
-                        _logger.LogInformation("Using codec {Codec} for video transcoding of {FileName}",
-                            preferredCodec, Path.GetFileName(fullname));
-
-                        // Transcode to h264 using ffmpeg with hardware acceleration if available
                         var ffmpegPath = _ffMpegService.FfMpegExecutable;
-                        var ffmpegCmd = Cli.Wrap(ffmpegPath)
+
+                        // Transcode to h264 using the given codec. Hardware-specific
+                        // tuning is selected based on the codec name.
+                        CliWrap.Command BuildTranscodeCommand(string codec) => Cli.Wrap(ffmpegPath)
                             .WithArguments(args =>
                             {
                                 args
                                     .Add("-i").Add(fullname)
-                                    .Add("-c:v").Add(preferredCodec);
+                                    .Add("-c:v").Add(codec);
 
                                 // Add hardware-specific options based on the codec
-                                if (preferredCodec == "h264_nvenc")
+                                if (codec == "h264_nvenc")
                                 {
                                     args
                                         .Add("-preset").Add("p1") // NVENC preset
                                         .Add("-tune").Add("hq"); // High quality tuning
                                 }
-                                else if (preferredCodec == "h264_qsv")
+                                else if (codec == "h264_qsv")
                                 {
                                     args
                                         .Add("-preset").Add("veryfast") // QSV preset
                                         .Add("-look_ahead").Add("1"); // Enable look-ahead
                                 }
-                                else if (preferredCodec == "h264_amf")
+                                else if (codec == "h264_amf")
                                 {
                                     args
                                         .Add("-quality").Add("speed") // AMF quality preset
                                         .Add("-rc").Add("cqp"); // Rate control
                                 }
-                                else if (preferredCodec == "h264_videotoolbox")
+                                else if (codec == "h264_videotoolbox")
                                 {
                                     args
                                         .Add("-allow_sw").Add("1"); // Allow software fallback
@@ -1498,6 +1498,13 @@ namespace Bakabase.Service.Controllers
                             })
                             .WithStandardOutputPipe(PipeTarget.ToStream(Response.Body, true));
 
+                        // Try the hardware-accelerated codec first; if it fails before
+                        // any output has been written, fall back to software encoding.
+                        const string softwareCodec = "libx264";
+                        var codecsToTry = preferredCodec == softwareCodec
+                            ? new[] { softwareCodec }
+                            : new[] { preferredCodec, softwareCodec };
+
                         // The file name may contain non-ASCII characters (e.g. CJK),
                         // which would throw when written as a raw header value, so
                         // encode per RFC 5987.
@@ -1506,15 +1513,49 @@ namespace Bakabase.Service.Controllers
                         var encodedName = Uri.EscapeDataString(displayName);
                         Response.Headers["Content-Disposition"] =
                             $"inline; filename*=UTF-8''{encodedName}";
-                        try
+
+                        for (var i = 0; i < codecsToTry.Length; i++)
                         {
-                            await ffmpegCmd.ExecuteAsync(HttpContext.RequestAborted);
+                            var codec = codecsToTry[i];
+                            var isLastAttempt = i == codecsToTry.Length - 1;
+
+                            _logger.LogInformation("Using codec {Codec} for video transcoding of {FileName}",
+                                codec, Path.GetFileName(fullname));
+
+                            try
+                            {
+                                await BuildTranscodeCommand(codec).ExecuteAsync(HttpContext.RequestAborted);
+                                break;
+                            }
+                            catch (OperationCanceledException)
+                                when (HttpContext.RequestAborted.IsCancellationRequested)
+                            {
+                                // Client navigated away / closed tab; not an error.
+                                break;
+                            }
+                            catch (CommandExecutionException ex)
+                            {
+                                // ffmpeg failed. If nothing has been written to the
+                                // response yet and another codec is available, retry
+                                // with it (typically hardware -> software fallback).
+                                if (!isLastAttempt && !Response.HasStarted)
+                                {
+                                    _logger.LogWarning(ex,
+                                        "Video transcoding with codec {Codec} failed for {FileName}, falling back to software encoding",
+                                        codec, Path.GetFileName(fullname));
+                                    continue;
+                                }
+
+                                // No fallback possible (response already streaming, or
+                                // this was the last codec). ffmpeg choking on a specific
+                                // file is an expected failure — log as a warning so it is
+                                // not reported as an error.
+                                _logger.LogWarning(ex, "Video transcoding failed for {FileName}",
+                                    Path.GetFileName(fullname));
+                                break;
+                            }
                         }
-                        catch (OperationCanceledException)
-                            when (HttpContext.RequestAborted.IsCancellationRequested)
-                        {
-                            // Client navigated away / closed tab; not an error.
-                        }
+
                         return new EmptyResult();
                     }
                 }

--- a/src/modules/Bakabase.Modules.Enhancer/Services/EnhancerService.cs
+++ b/src/modules/Bakabase.Modules.Enhancer/Services/EnhancerService.cs
@@ -714,7 +714,23 @@ namespace Bakabase.Modules.Enhancer.Services
                             foreach (var task in nextTasks)
                             {
                                 var resource =
-                                    (await resourceService.Get(task.Resource.Id, ResourceAdditionalItem.All))!;
+                                    await resourceService.Get(task.Resource.Id, ResourceAdditionalItem.All);
+                                if (resource == null)
+                                {
+                                    // The resource was deleted after the task list was built.
+                                    // Skip it, but still release dependents and remove it from
+                                    // the set so the loop can keep making progress.
+                                    _logger.LogWarning(
+                                        $"Resource [{task.Resource.Id}] no longer exists, skipping enhancement by [{task.Enhancer.Id}:{(EnhancerId)task.Enhancer.Id}]");
+                                    foreach (var dep in task.Dependents)
+                                    {
+                                        dep.Dependencies?.Remove(task);
+                                    }
+
+                                    set.Remove(task);
+                                    continue;
+                                }
+
                                 List<Enhancement>? enhancements = null;
                                 List<EnhancementLog>? logs = null;
                                 string? errorMessage = null;

--- a/src/web/src/components/ResourceDetailLayoutEditor/MasonryCanvas.tsx
+++ b/src/web/src/components/ResourceDetailLayoutEditor/MasonryCanvas.tsx
@@ -207,16 +207,16 @@ export function MasonryCanvas({ config, renderSection, onConfigChange }: Props) 
 
     dragStateRef.current = null;
     if (!ds) return;
-    setPreviewConfig((prev) => {
-      if (prev) {
-        const compacted = settleLayout(prev.blocks, { movedId: ds.id });
+    // onConfigChange must not be called inside a setPreviewConfig updater:
+    // updater functions have to be pure, and React may re-run them, which
+    // re-triggers the parent update and causes an infinite render loop.
+    if (previewConfig) {
+      const compacted = settleLayout(previewConfig.blocks, { movedId: ds.id });
 
-        onConfigChange?.({ ...prev, blocks: compacted });
-      }
-
-      return null;
-    });
-  }, [onConfigChange]);
+      onConfigChange?.({ ...previewConfig, blocks: compacted });
+    }
+    setPreviewConfig(null);
+  }, [onConfigChange, previewConfig]);
 
   useEffect(() => {
     window.addEventListener("pointermove", onDragPointerMove);
@@ -304,16 +304,14 @@ export function MasonryCanvas({ config, renderSection, onConfigChange }: Props) 
 
     resizeStateRef.current = null;
     if (!rs) return;
-    setPreviewConfig((prev) => {
-      if (prev) {
-        const compacted = settleLayout(prev.blocks, { movedId: rs.id });
+    // See onDragPointerUp: keep onConfigChange out of the updater function.
+    if (previewConfig) {
+      const compacted = settleLayout(previewConfig.blocks, { movedId: rs.id });
 
-        onConfigChange?.({ ...prev, blocks: compacted });
-      }
-
-      return null;
-    });
-  }, [onConfigChange]);
+      onConfigChange?.({ ...previewConfig, blocks: compacted });
+    }
+    setPreviewConfig(null);
+  }, [onConfigChange, previewConfig]);
 
   useEffect(() => {
     window.addEventListener("pointermove", onResizePointerMove);

--- a/src/web/src/components/bakaui/components/Select/index.tsx
+++ b/src/web/src/components/bakaui/components/Select/index.tsx
@@ -29,6 +29,12 @@ const Select: React.FC<SelectProps> = ({ dataSource = [], ...props }) => {
 
   const isMultiline = props.selectionMode === "multiple";
 
+  // Each item is rendered as <SelectItem key={data.value}>. An item without a
+  // usable value produces a keyless node, and react-stately throws
+  // "No key found for item" while building the collection, crashing the whole
+  // page. Drop such items — an option with no value can't be selected anyway.
+  const items = dataSource.filter((d) => d != null && d.value != null);
+
   // console.log(props.selectedKeys, dataSource);
   const baseRenderValue =
     props.renderValue ??
@@ -64,7 +70,7 @@ const Select: React.FC<SelectProps> = ({ dataSource = [], ...props }) => {
     <HeroSelect
       // aria-label={'Select'}
       isMultiline={isMultiline}
-      items={dataSource ?? []}
+      items={items}
       renderValue={renderValue}
       {...props}
     >


### PR DESCRIPTION
## 概述

修复 Sentry 上报的 4 个生产崩溃。第 5 个（FC2 SSL 错误，BAKABASE-SERVICE-19）此前已由 commit `2fd1762` 修复，本次无需改动。

## 改动

### 前端

- **Select 选项缺少 key 导致整页崩溃**（#1137）
  `bakaui/Select` 过滤掉 `value` 为空的 `dataSource` 选项，避免渲染出无 key 的 `SelectItem` 触发 react-stately 抛出 `No key found for item`。

- **资源详情布局编辑器无限重渲染**（#1138）
  `MasonryCanvas` 的 `onDragPointerUp` / `onResizePointerUp` 不再在 `setPreviewConfig` 的 updater 函数内调用 `onConfigChange`；改为在事件处理函数中直接读取 `previewConfig` 计算并提交。

### 后端

- **增强任务 NullReferenceException**（#1139）
  `EnhancerService.CreateEnhancementContext` 重新获取资源后判空；资源已被删除时跳过该任务，并解除其依赖、从待处理集合移除。

- **视频转码硬件编码器失败缺少软件回退**（#1140）
  `FileController.Play` 在硬件编码器失败且响应尚未开始时回退到 `libx264` 软件编码；所有编码器都失败时记录为 Warning，避免对个别异常文件刷 Sentry。

## 验证说明

> 本运行环境缺少 dotnet、且网络限制导致前端依赖无法安装，故未能跑编译 / tsc / lint。改动均已逐行 review，前端两处改动为类型安全的小改动。建议在本地补充编译与手动验证。

Resolves #1137
Resolves #1138
Resolves #1139
Resolves #1140

https://claude.ai/code/session_01KHsepaeM7SRL872csBV2PD

---
_Generated by [Claude Code](https://claude.ai/code/session_01KHsepaeM7SRL872csBV2PD)_