### PR TITLE
ci: simplify workflow_dispatch trigger in deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,12 +8,10 @@ on:
     #   - 'v*'
   # pull_request:
   #   branches: [ main, 'dev/v*' ]
+  # Manual trigger for the full build + deploy + release pipeline.
+  # [skip ci] only blocks push and pull_request, not workflow_dispatch, so this
+  # is how to run the pipeline for a commit whose push was skipped.
   workflow_dispatch:
-  #   inputs:
-  #     tag:
-  #       description: 'tag (e.g., v1.2.3, 1.2.3, v1.2.3-alpha)'
-  #       required: true
-  #       type: string
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
Removed unused input parameters from the `workflow_dispatch` trigger in the GitHub Actions deploy workflow. The manual trigger is now simplified to its essential form.

## Changes
- Removed commented-out `inputs` section (tag parameter) from `workflow_dispatch`
- Added clarifying comments explaining the purpose of `workflow_dispatch`: to allow manual pipeline execution for commits whose push was skipped via `[skip ci]`

## Details
The `workflow_dispatch` trigger enables running the full build + deploy + release pipeline manually, which is useful for commits marked with `[skip ci]` (since `[skip ci]` only blocks `push` and `pull_request` events, not manual workflow triggers). The tag input was not being used and has been removed to keep the configuration clean.

https://claude.ai/code/session_014KsxCpu2W4M1hKsvh5G8yB