### PR TITLE
Fix AV mosaic parsing to return boolean instead of string

### DIFF
--- a/src/modules/Bakabase.Modules.Enhancer/Components/Enhancers/Av/AvEnhancer.cs
+++ b/src/modules/Bakabase.Modules.Enhancer/Components/Enhancers/Av/AvEnhancer.cs
@@ -292,7 +292,7 @@ public class AvEnhancer(
                     AddStringEnhancement(orderedDetails, d => d.Website, target, enhancements);
                     break;
                 case AvEnhancerTarget.Mosaic:
-                    AddStringEnhancement(orderedDetails, d => d.Mosaic, target, enhancements);
+                    AddBooleanEnhancement(orderedDetails, d => ParseMosaic(d.Mosaic), target, enhancements);
                     break;
                 case AvEnhancerTarget.Introduction:
                     AddStringEnhancement(orderedDetails, d => d.Outline, target, enhancements);
@@ -419,6 +419,56 @@ public class AvEnhancer(
             enhancements.Add(new EnhancementTargetValue<AvEnhancerTarget>(target, null,
                 new ListStringValueBuilder(values)));
         }
+    }
+
+    private static void AddBooleanEnhancement(IReadOnlyList<IAvDetail> details, Func<IAvDetail, bool?> selector,
+        AvEnhancerTarget target, List<EnhancementTargetValue<AvEnhancerTarget>> enhancements)
+    {
+        // Use the first source (respecting preferred-source ordering) that yields a
+        // definitive value; skip sources whose value can't be interpreted.
+        foreach (var d in details)
+        {
+            var value = selector(d);
+            if (value.HasValue)
+            {
+                enhancements.Add(new EnhancementTargetValue<AvEnhancerTarget>(target, null,
+                    new BooleanValueBuilder(value)));
+                return;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Interprets the raw mosaic string from AV sources (e.g. "有码"/"无码"/"国产"/"同人"/"里番")
+    /// as a "has mosaic" (censored) boolean:
+    ///   - uncensored markers (无码/無碼/無修正/uncensored) → false
+    ///   - censored markers (有码/有碼)                     → true
+    ///   - anything else (国产/同人/里番/empty/unknown)      → null
+    /// Returning null avoids forcing an arbitrary true/false for values that don't actually
+    /// describe the mosaic state, which is why mapping these strings straight to a Boolean
+    /// property used to always yield "true".
+    /// </summary>
+    internal static bool? ParseMosaic(string? mosaic)
+    {
+        if (string.IsNullOrWhiteSpace(mosaic))
+        {
+            return null;
+        }
+
+        var v = mosaic.Trim();
+
+        if (v.Contains("无码") || v.Contains("無碼") || v.Contains("無修正") ||
+            v.Contains("uncensored", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (v.Contains("有码") || v.Contains("有碼"))
+        {
+            return true;
+        }
+
+        return null;
     }
 
 }

--- a/src/modules/Bakabase.Modules.Enhancer/Components/Enhancers/Av/AvEnhancerTarget.cs
+++ b/src/modules/Bakabase.Modules.Enhancer/Components/Enhancers/Av/AvEnhancerTarget.cs
@@ -38,7 +38,7 @@ public enum AvEnhancerTarget
     Poster,
     [EnhancerTarget(StandardValueType.String, PropertyType.SingleLineText)]
     Website,
-    [EnhancerTarget(StandardValueType.String, PropertyType.SingleLineText)]
+    [EnhancerTarget(StandardValueType.Boolean, PropertyType.Boolean)]
     Mosaic,
     [EnhancerTarget(StandardValueType.String, PropertyType.MultilineText, null, false, null, ReservedProperty.Introduction)]
     Introduction

--- a/src/tests/Bakabase.Modules.Enhancer.Tests/AvMosaicParsingTests.cs
+++ b/src/tests/Bakabase.Modules.Enhancer.Tests/AvMosaicParsingTests.cs
@@ -1,0 +1,53 @@
+using Bakabase.Modules.Enhancer.Components.Enhancers.Av;
+using FluentAssertions;
+
+namespace Bakabase.Modules.Enhancer.Tests;
+
+/// <summary>
+/// Pins the mapping of the AV enhancer's raw mosaic string to a "has mosaic"
+/// (censored) boolean. The bug this guards against: the Mosaic target used to be
+/// declared as a plain string, so binding it to a Boolean property routed the
+/// value through the generic string→boolean conversion — which treats any
+/// non-empty, non-"0"/"false" string as <c>true</c>. That made every result
+/// (有码 AND 无码 AND 国产 …) come out as "有"/true.
+///
+/// **Contract:** uncensored markers → false, censored markers → true, and any
+/// value that does not actually describe the mosaic state (国产/同人/里番/empty)
+/// → null, so the enhancer never asserts an arbitrary boolean.
+/// </summary>
+[TestClass]
+public sealed class AvMosaicParsingTests
+{
+    [DataTestMethod]
+    [DataRow("无码")]
+    [DataRow("無碼")]
+    [DataRow("無修正")]
+    [DataRow("uncensored")]
+    [DataRow("Uncensored")]
+    [DataRow(" 无码 ")]
+    public void Uncensored_ReturnsFalse(string raw)
+    {
+        AvEnhancer.ParseMosaic(raw).Should().BeFalse();
+    }
+
+    [DataTestMethod]
+    [DataRow("有码")]
+    [DataRow("有碼")]
+    [DataRow(" 有码 ")]
+    public void Censored_ReturnsTrue(string raw)
+    {
+        AvEnhancer.ParseMosaic(raw).Should().BeTrue();
+    }
+
+    [DataTestMethod]
+    [DataRow("国产")]
+    [DataRow("同人")]
+    [DataRow("里番")]
+    [DataRow("")]
+    [DataRow("   ")]
+    [DataRow(null)]
+    public void NonMosaicOrUnknown_ReturnsNull(string? raw)
+    {
+        AvEnhancer.ParseMosaic(raw).Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary
Fixed a bug in the AV enhancer where the mosaic field was incorrectly parsed as a string instead of a boolean. The generic string-to-boolean conversion was treating any non-empty string as `true`, causing all results (censored, uncensored, and non-mosaic categories) to incorrectly report as censored.

## Changes
- **AvEnhancerTarget.cs**: Changed `Mosaic` target type from `StandardValueType.String` to `StandardValueType.Boolean`
- **AvEnhancer.cs**: 
  - Replaced `AddStringEnhancement` with `AddBooleanEnhancement` for mosaic handling
  - Added `AddBooleanEnhancement` helper method to select the first source with a definitive boolean value
  - Added `ParseMosaic(string?)` method to interpret raw mosaic strings:
    - Uncensored markers (无码/無碼/無修正/uncensored) → `false`
    - Censored markers (有码/有碼) → `true`
    - Non-mosaic values (国产/同人/里番/empty/whitespace) → `null`
- **AvMosaicParsingTests.cs**: Added comprehensive test suite covering all mosaic parsing cases

## Implementation Details
The `ParseMosaic` method returns `null` for values that don't describe the actual mosaic state, allowing the enhancer to skip sources that provide ambiguous data rather than forcing an arbitrary boolean. This prevents the previous behavior where every result would incorrectly report as censored.

https://claude.ai/code/session_013Wsv7S89SqKpG8gCHQu2v4