### PR TITLE
chore: disable auto-apply on startup for Velopack updates

### DIFF
--- a/src/apps/Bakabase/Program.cs
+++ b/src/apps/Bakabase/Program.cs
@@ -10,7 +10,16 @@ class Program
     {
         // Velopack must be the first thing to run in the app.
         // It handles install/uninstall/update lifecycle hooks.
-        VelopackApp.Build().Run();
+        //
+        // SetAutoApplyOnStartup(false): by default Velopack silently applies an
+        // already-downloaded update on the next launch (before any UI shows).
+        // We auto-download upgrade packages but want the install itself to be a
+        // deliberate user action, so we disable that implicit apply. A staged
+        // update then stays as PendingRestart until the user clicks "restart to
+        // update", which explicitly calls UpdateManager.ApplyUpdatesAndRestart.
+        VelopackApp.Build()
+            .SetAutoApplyOnStartup(false)
+            .Run();
 
         BuildAvaloniaApp()
             .StartWithClassicDesktopLifetime(args);


### PR DESCRIPTION
## Summary
Configure Velopack to not automatically apply downloaded updates on startup, ensuring updates are only applied when the user explicitly chooses to restart.

## Changes
- Modified `VelopackApp.Build()` initialization in `Program.cs` to call `.SetAutoApplyOnStartup(false)`
- Added detailed comments explaining the rationale: while the app auto-downloads update packages, the installation itself should be a deliberate user action rather than happening silently before the UI appears
- Staged updates now remain in `PendingRestart` state until the user clicks "restart to update", which explicitly calls `UpdateManager.ApplyUpdatesAndRestart`

## Implementation Details
This change gives users explicit control over when updates are applied, improving the user experience by avoiding unexpected restarts while still supporting background downloading of update packages.

https://claude.ai/code/session_011ykxQADXEVkGU5k3znBLGu