### PR TITLE
feat(downloader): add ExHentai "prioritize tasks with torrent" option

### DIFF
--- a/src/apps/Bakabase.Service/Controllers/OptionsController.cs
+++ b/src/apps/Bakabase.Service/Controllers/OptionsController.cs
@@ -391,6 +391,11 @@ namespace Bakabase.Service.Controllers
                     options.PreferTorrent = model.PreferTorrent.Value;
                 }
 
+                if (model.PrioritizeTasksWithTorrent.HasValue)
+                {
+                    options.PrioritizeTasksWithTorrent = model.PrioritizeTasksWithTorrent.Value;
+                }
+
                 if (model.ShowCover.HasValue)
                 {
                     options.ShowCover = model.ShowCover.Value;

--- a/src/legacy/Bakabase.InsideWorld.Business/Components/Configurations/Models/Domain/ExHentaiOptions.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Components/Configurations/Models/Domain/ExHentaiOptions.cs
@@ -52,6 +52,14 @@ namespace Bakabase.InsideWorld.Business.Components.Configurations.Models.Domain
         /// </summary>
         public bool PreferTorrent { get; set; } = true;
 
+        /// <summary>
+        /// When enabled (only meaningful while <see cref="PreferTorrent"/> is on), SingleWork tasks
+        /// that turn out to have a torrent are processed first: a task without a torrent yields its
+        /// download slot back to the queue after probing, so torrent-bearing tasks are drained before
+        /// any image-only task starts downloading. Global runtime switch, not frozen per task.
+        /// </summary>
+        public bool PrioritizeTasksWithTorrent { get; set; }
+
         public bool SkipExisting { get; set; }
         public int MaxRetries { get; set; }
         public int RequestTimeout { get; set; }

--- a/src/legacy/Bakabase.InsideWorld.Business/Components/Configurations/Models/Input/ExHentaiOptionsPatchInputModel.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Components/Configurations/Models/Input/ExHentaiOptionsPatchInputModel.cs
@@ -12,6 +12,7 @@ public class ExHentaiOptionsPatchInputModel
     public string? DefaultPath { get; set; }
     public string? NamingConvention { get; set; }
     public bool? PreferTorrent { get; set; }
+    public bool? PrioritizeTasksWithTorrent { get; set; }
     public bool? SkipExisting { get; set; }
     public int? MaxRetries { get; set; }
     public int? RequestTimeout { get; set; }

--- a/src/legacy/Bakabase.InsideWorld.Business/Components/Downloader/Abstractions/Models/Constants/DownloaderStopBy.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Components/Downloader/Abstractions/Models/Constants/DownloaderStopBy.cs
@@ -3,6 +3,14 @@
     public enum DownloaderStopBy
     {
         ManuallyStop = 1,
-        AppendToTheQueue = 2
+        AppendToTheQueue = 2,
+
+        /// <summary>
+        /// The task voluntarily yielded its slot back to the queue without failing or completing
+        /// (e.g. ExHentai torrent-priority deferring a no-torrent task). Like
+        /// <see cref="AppendToTheQueue"/> it stays eligible, but it also triggers the scheduler to
+        /// immediately pick the next task.
+        /// </summary>
+        Defer = 3
     }
 }

--- a/src/legacy/Bakabase.InsideWorld.Business/Components/Downloader/Components/DownloaderManager.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Components/Downloader/Components/DownloaderManager.cs
@@ -26,6 +26,13 @@ namespace Bakabase.InsideWorld.Business.Components.Downloader.Components
         private readonly IServiceProvider _serviceProvider;
         private readonly ConcurrentDictionary<int, IDownloader> _downloaders = new();
         private readonly ConcurrentDictionary<int, TaskCompletionSource> _downloadBTaskCompletionSources = new();
+
+        /// <summary>
+        /// In-memory verdicts for ExHentai torrent-priority: task ids known (during the current run)
+        /// to have no torrent. Used by the scheduler to deprioritize them and by the downloader to
+        /// stop deferring them. Transient by design — it is rebuilt by re-probing after a restart.
+        /// </summary>
+        private readonly ConcurrentDictionary<int, byte> _noTorrentTaskIds = new();
         private readonly IStringLocalizer<SharedResource> _localizer;
         private readonly IDownloaderLocalizer _downloaderLocalizer;
         private readonly IDownloaderFactory _downloaderFactory;
@@ -56,6 +63,17 @@ namespace Bakabase.InsideWorld.Business.Components.Downloader.Components
                     CompleteBTask(taskId);
                 }
 
+                // Drop the torrent-priority verdict once the task truly ends (success / failure /
+                // manual stop) so a later restart re-probes it. A Defer / AppendToTheQueue stop is a
+                // requeue, not an end, so the verdict must survive it — otherwise we would re-defer
+                // forever.
+                if (downloader.Status is DownloaderStatus.Complete or DownloaderStatus.Failed ||
+                    (downloader.Status == DownloaderStatus.Stopped &&
+                     downloader.StoppedBy == DownloaderStopBy.ManuallyStop))
+                {
+                    ClearNoTorrent(taskId);
+                }
+
                 return Task.CompletedTask;
             };
             OnNameAcquired += (taskId, name) =>
@@ -81,6 +99,15 @@ namespace Bakabase.InsideWorld.Business.Components.Downloader.Components
         public event Func<int, string, Task> OnCheckpointReached;
 
         public IDownloader? this[int taskId] => _downloaders.GetValueOrDefault(taskId);
+
+        /// <summary>Record that a task has been probed and has no torrent (ExHentai torrent-priority).</summary>
+        public void MarkNoTorrent(int taskId) => _noTorrentTaskIds[taskId] = 0;
+
+        /// <summary>Whether a task is already known (this run) to have no torrent.</summary>
+        public bool IsKnownNoTorrent(int taskId) => _noTorrentTaskIds.ContainsKey(taskId);
+
+        /// <summary>Forget a task's no-torrent verdict so it is re-probed next time it runs.</summary>
+        public void ClearNoTorrent(int taskId) => _noTorrentTaskIds.TryRemove(taskId, out _);
 
         public async Task Stop(int taskId, DownloaderStopBy stopBy)
         {

--- a/src/legacy/Bakabase.InsideWorld.Business/Components/Downloader/Components/Downloaders/AbstractDownloader.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Components/Downloader/Components/Downloaders/AbstractDownloader.cs
@@ -227,6 +227,14 @@ namespace Bakabase.InsideWorld.Business.Components.Downloader.Components.Downloa
                             Status = DownloaderStatus.Stopped;
                         }
                     }
+                    catch (DownloadDeferredException)
+                    {
+                        // The task gave up its slot on purpose (e.g. no torrent under torrent-priority).
+                        // Mark it Stopped/Defer so it stays eligible and the scheduler advances, without
+                        // counting as a failure.
+                        StoppedBy = DownloaderStopBy.Defer;
+                        Status = DownloaderStatus.Stopped;
+                    }
                     catch (Exception e)
                     {
                         FailureTimes++;

--- a/src/legacy/Bakabase.InsideWorld.Business/Components/Downloader/Components/Downloaders/DownloadDeferredException.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Components/Downloader/Components/Downloaders/DownloadDeferredException.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Bakabase.InsideWorld.Business.Components.Downloader.Components.Downloaders
+{
+    /// <summary>
+    /// Thrown by a downloader to voluntarily yield its download slot back to the queue without
+    /// failing or completing the task. Used by ExHentai torrent-priority: a SingleWork task that
+    /// turns out to have no torrent is deferred (and marked) so torrent-bearing tasks are processed
+    /// first. <see cref="AbstractDownloader{TEnumTaskType}.Start"/> maps it to a
+    /// <see cref="Abstractions.Models.Constants.DownloaderStopBy.Defer"/> stop.
+    /// </summary>
+    public class DownloadDeferredException : Exception
+    {
+        public DownloadDeferredException() : base("Download deferred to prioritize tasks with torrents.")
+        {
+        }
+    }
+}

--- a/src/legacy/Bakabase.InsideWorld.Business/Components/Downloader/Components/Downloaders/ExHentai/AbstractExHentaiDownloader.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Components/Downloader/Components/Downloaders/ExHentai/AbstractExHentaiDownloader.cs
@@ -44,7 +44,9 @@ namespace Bakabase.InsideWorld.Business.Components.Downloader.Components.Downloa
             Func<decimal, Task> onProgress,
             Func<string, Task> onCheckpointChanged,
             CancellationToken ct,
-            bool preferTorrent = true)
+            bool preferTorrent = true,
+            bool deferIfNoTorrent = false,
+            Action? onNoTorrentDetected = null)
         {
             // Only fetch torrent info when preferTorrent is true
             var detail = await Client.ParseDetail(url, preferTorrent);
@@ -88,6 +90,16 @@ namespace Bakabase.InsideWorld.Business.Components.Downloader.Components.Downloa
                 }
 
                 return;
+            }
+
+            // Reached here => this gallery has no torrent. Under torrent-priority, yield the slot back
+            // to the queue (after recording the verdict) so torrent-bearing tasks are drained first.
+            // The deferred task is re-selected only once no un-probed task remains, at which point this
+            // method is called again with deferIfNoTorrent=false and proceeds to download images.
+            if (deferIfNoTorrent)
+            {
+                onNoTorrentDetected?.Invoke();
+                throw new DownloadDeferredException();
             }
 
             var baseNameSegmentsValues = new Dictionary<ExHentaiNamingFields, object?>

--- a/src/legacy/Bakabase.InsideWorld.Business/Components/Downloader/Components/Downloaders/ExHentai/ExHentaiSingleWorkDownloader.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Components/Downloader/Components/Downloaders/ExHentai/ExHentaiSingleWorkDownloader.cs
@@ -2,8 +2,10 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Bakabase.Abstractions.Services;
+using Bakabase.InsideWorld.Business.Components.Configurations.Models.Domain;
 using Bakabase.InsideWorld.Business.Components.Downloader.Abstractions.Models;
 using Bakabase.Modules.ThirdParty.ThirdParties.ExHentai;
+using Bootstrap.Components.Configuration.Abstractions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Localization;
 
@@ -22,12 +24,21 @@ namespace Bakabase.InsideWorld.Business.Components.Downloader.Components.Downloa
 
         protected override async Task StartCore(DownloadTask task, ExHentaiTaskOptions options, CancellationToken ct)
         {
+            var exOptions = GetRequiredService<IBOptionsManager<ExHentaiOptions>>().Value;
+            var manager = DownloaderManager;
+            // Defer (probe-then-yield) only on the first pass of an un-probed task. Once it is known to
+            // have no torrent, it is re-run with deferIfNoTorrent=false and downloads images normally.
+            var deferIfNoTorrent = exOptions.PrioritizeTasksWithTorrent
+                                   && options.PreferTorrent
+                                   && !manager.IsKnownNoTorrent(task.Id);
+
             await DownloadSingleWork(task.Key, task.Checkpoint, task.DownloadPath, OnNameAcquiredInternal,
                 async current =>
                 {
                     Current = current;
                     await OnCurrentChangedInternal();
-                }, OnProgressInternal, OnCheckpointChangedInternal, ct, options.PreferTorrent);
+                }, OnProgressInternal, OnCheckpointChangedInternal, ct, options.PreferTorrent,
+                deferIfNoTorrent, () => manager.MarkNoTorrent(task.Id));
         }
     }
 }

--- a/src/legacy/Bakabase.InsideWorld.Business/Components/Downloader/Extensions/DownloaderExtensions.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Components/Downloader/Extensions/DownloaderExtensions.cs
@@ -85,9 +85,13 @@ namespace Bakabase.InsideWorld.Business.Components.Downloader.Extensions
                         DownloaderStatus.Stopped => DownloadTaskStatus.Disabled,
                         _ => throw new ArgumentOutOfRangeException()
                     };
-                    // Same as JustCreated
+                    // Same as JustCreated. Defer is a voluntary requeue (torrent-priority), so it must
+                    // stay eligible just like AppendToTheQueue instead of looking Disabled.
                     if (downloader is
-                        { Status: DownloaderStatus.Stopped, StoppedBy: DownloaderStopBy.AppendToTheQueue })
+                        {
+                            Status: DownloaderStatus.Stopped,
+                            StoppedBy: DownloaderStopBy.AppendToTheQueue or DownloaderStopBy.Defer
+                        })
                     {
                         status = allDownloaders.Any(a =>
                             a.Key != task.Id && a.Value.ThirdPartyId == task.ThirdPartyId &&

--- a/src/legacy/Bakabase.InsideWorld.Business/Components/Downloader/Services/DownloadTaskService.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Components/Downloader/Services/DownloadTaskService.cs
@@ -4,15 +4,19 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Bakabase.Infrastructures.Components.Gui;
+using Bakabase.InsideWorld.Business.Components.Configurations.Models.Domain;
 using Bakabase.InsideWorld.Business.Components.Downloader.Abstractions.Components;
 using Bakabase.InsideWorld.Business.Components.Downloader.Abstractions.Models.Constants;
 using Bakabase.InsideWorld.Business.Components.Downloader.Abstractions.Models.Input;
 using Bakabase.InsideWorld.Business.Components.Downloader.Components;
+using Bakabase.InsideWorld.Business.Components.Downloader.Components.Downloaders.ExHentai;
 using Bakabase.InsideWorld.Business.Components.Downloader.Extensions;
 using Bakabase.InsideWorld.Business.Components.Downloader.Models.Db;
 using Bakabase.InsideWorld.Business.Components.Gui;
 using Bakabase.InsideWorld.Business.Workflow;
+using Bakabase.InsideWorld.Models.Constants;
 using Bakabase.Modules.Workflow.Abstractions.Components;
+using Bootstrap.Components.Configuration.Abstractions;
 using Bootstrap.Components.Miscellaneous.ResponseBuilders;
 using Bootstrap.Components.Office.Excel;
 using Bootstrap.Components.Orm.Infrastructures;
@@ -150,6 +154,7 @@ namespace Bakabase.InsideWorld.Business.Components.Downloader.Services
                             newStatus = DownloadTaskDbModelStatus.Disabled;
                             break;
                         case DownloaderStopBy.AppendToTheQueue:
+                        case DownloaderStopBy.Defer:
                             newStatus = DownloadTaskDbModelStatus.InProgress;
                             break;
                         default:
@@ -184,8 +189,13 @@ namespace Bakabase.InsideWorld.Business.Components.Downloader.Services
                 }
 
                 await base.Update(task);
+                // A Defer keeps the task eligible (InProgress) but, unlike other requeues, must kick
+                // the scheduler so the next task is picked immediately rather than waiting for the
+                // periodic trigger.
+                var deferred = downloader is
+                    { Status: DownloaderStatus.Stopped, StoppedBy: DownloaderStopBy.Defer };
                 if (newStatus is DownloadTaskDbModelStatus.Complete or DownloadTaskDbModelStatus.Failed
-                    or DownloadTaskDbModelStatus.Disabled)
+                        or DownloadTaskDbModelStatus.Disabled || deferred)
                 {
                     await TryStartAllTasks(DownloadTaskStartMode.AutoStart, null, DownloadTaskActionOnConflict.Ignore);
                 }
@@ -213,6 +223,13 @@ namespace Bakabase.InsideWorld.Business.Components.Downloader.Services
                 ToDto(new[] {task}).FirstOrDefault()!);
         }
 
+        // True when an ExHentai task will end up downloading images (so under torrent-priority it should
+        // run after torrent-bearing tasks): it has been probed and has no torrent, or it opts out of
+        // torrents (PreferTorrent off), in which case we honor that and download its images.
+        private bool IsExHentaiImageOnly(DownloadTask task) =>
+            DownloaderManager.IsKnownNoTorrent(task.Id) ||
+            !task.GetTypedOptions<ExHentaiTaskOptions>().PreferTorrent;
+
         public async Task<BaseResponse> TryStartAllTasks(DownloadTaskStartMode mode, int[]? ids,
             DownloadTaskActionOnConflict actionOnConflict)
         {
@@ -230,7 +247,25 @@ namespace Bakabase.InsideWorld.Business.Components.Downloader.Services
                     };
                 }).ToArray();
 
-            var filteredTasks = targetTasks.GroupBy(a => a.ThirdPartyId).Select(a => a.FirstOrDefault()!).ToArray();
+            var prioritizeExTorrent = GetRequiredService<IBOptionsManager<ExHentaiOptions>>().Value
+                .PrioritizeTasksWithTorrent;
+            var filteredTasks = targetTasks.GroupBy(a => a.ThirdPartyId)
+                .Select(g =>
+                {
+                    // ExHentai torrent-priority: probe torrent-preferring, un-probed tasks first. Tasks
+                    // that will end up downloading images — already probed with no torrent, or opting
+                    // out of torrents — sink to the back, so they only start once there is nothing
+                    // torrent-bearing left. Stable FIFO (by id) within each tier.
+                    if (prioritizeExTorrent && g.Key == ThirdPartyId.ExHentai)
+                    {
+                        return g.OrderBy(t => IsExHentaiImageOnly(t) ? 1 : 0)
+                            .ThenBy(t => t.Id)
+                            .First();
+                    }
+
+                    return g.FirstOrDefault()!;
+                })
+                .ToArray();
             var startedTasks = new List<DownloadTask>();
 
             foreach (var tt in filteredTasks)
@@ -337,6 +372,9 @@ namespace Bakabase.InsideWorld.Business.Components.Downloader.Services
         {
             await DownloaderManager.Stop(id, DownloaderStopBy.ManuallyStop);
             var rsp = await base.UpdateByKey(id, modify);
+            // The task's options (incl. PreferTorrent) may have changed, so drop any stale torrent
+            // verdict and let it be re-probed on the next run.
+            DownloaderManager.ClearNoTorrent(id);
             PushAllDataToUi();
             return rsp;
         }

--- a/src/web/src/components/ThirdPartyConfig/platforms/ExHentaiConfig.tsx
+++ b/src/web/src/components/ThirdPartyConfig/platforms/ExHentaiConfig.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState, type FC } from "react";
 import { useTranslation } from "react-i18next";
-import { Textarea } from "@heroui/react";
+import { CheckboxGroup, Textarea } from "@heroui/react";
 
 import AccountsPanel, { type AccountField } from "../base/AccountsPanel";
 import ConfigurableThirdPartyPanel, {
@@ -13,7 +13,7 @@ import TampermonkeyInstallButton from "../base/TampermonkeyInstallButton";
 import AutoSyncPanel from "../base/AutoSyncPanel";
 import ThirdPartyConfigModal from "../base/ThirdPartyConfigModal";
 
-import { Chip, NumberInput, toast } from "@/components/bakaui";
+import { Checkbox, Chip, NumberInput, toast } from "@/components/bakaui";
 import { FileSystemSelectorButton } from "@/components/FileSystemSelector";
 import BApi from "@/sdk/BApi";
 import { useExHentaiOptionsStore } from "@/stores/options";
@@ -200,6 +200,17 @@ export const ExHentaiConfigPanel: FC<ExHentaiConfigPanelProps> = ({ fields = "al
               preferTorrent={options?.preferTorrent ?? true}
               onChange={(v) => patch({ preferTorrent: v })}
             />
+            <CheckboxGroup
+              description={t<string>("downloader.tip.prioritizeTasksWithTorrentDesc")}
+              isDisabled={!(options?.preferTorrent ?? true)}
+              label={t<string>("downloader.label.prioritizeTasksWithTorrent")}
+              orientation="horizontal"
+              size="sm"
+              value={options?.prioritizeTasksWithTorrent ? ["yes"] : []}
+              onValueChange={(v) => patch({ prioritizeTasksWithTorrent: v.includes("yes") })}
+            >
+              <Checkbox value="yes">{t("common.label.yes")}</Checkbox>
+            </CheckboxGroup>
           </div>
         ),
       },

--- a/src/web/src/locales/cn/pages/downloader.json
+++ b/src/web/src/locales/cn/pages/downloader.json
@@ -70,6 +70,8 @@
   "End page": "结束页",
   "downloader.label.preferTorrent": "优先下载种子",
   "downloader.tip.preferTorrentDesc": "如果可用，优先下载种子文件而非直接下载图片。",
+  "downloader.label.prioritizeTasksWithTorrent": "优先下载包含种子的任务",
+  "downloader.tip.prioritizeTasksWithTorrentDesc": "勾选后，会先依次探测各任务，把包含种子的任务优先下完（仅下载 .torrent 文件），没有种子的任务排到最后再逐页下载图片。仅对单作品任务生效，需先开启“优先下载种子”。",
   "downloader.tip.exHentaiUserscript": "您可以使用我们提供的油猴脚本在 ExHentai 网站上一键下载。",
   "downloader.tip.goToThirdPartyIntegration": "前往第三方集成页面",
   "downloader.bilibili.selectFavorites": "选择收藏夹",

--- a/src/web/src/locales/en/pages/downloader.json
+++ b/src/web/src/locales/en/pages/downloader.json
@@ -70,6 +70,8 @@
   "End page": "End page",
   "downloader.label.preferTorrent": "Prefer torrent download",
   "downloader.tip.preferTorrentDesc": "If available, download torrent files instead of downloading images directly.",
+  "downloader.label.prioritizeTasksWithTorrent": "Prioritize tasks that have a torrent",
+  "downloader.tip.prioritizeTasksWithTorrentDesc": "When enabled, tasks are probed one by one and those that have a torrent are finished first (only the .torrent file is downloaded), while tasks without a torrent are pushed to the back to download images last. SingleWork tasks only; requires \"Prefer torrent download\".",
   "downloader.tip.exHentaiUserscript": "You can use our Tampermonkey userscript to download from ExHentai with one click.",
   "downloader.tip.goToThirdPartyIntegration": "Go to Third-Party Integration",
   "downloader.bilibili.selectFavorites": "Select favorites",

--- a/src/web/src/sdk/Api.ts
+++ b/src/web/src/sdk/Api.ts
@@ -1316,6 +1316,7 @@ export interface BakabaseInsideWorldBusinessComponentsConfigurationsModelsDomain
   defaultPath?: string;
   namingConvention?: string;
   preferTorrent: boolean;
+  prioritizeTasksWithTorrent: boolean;
   skipExisting: boolean;
   /** @format int32 */
   maxRetries: number;
@@ -1570,6 +1571,7 @@ export interface BakabaseInsideWorldBusinessComponentsConfigurationsModelsInputE
   defaultPath?: string;
   namingConvention?: string;
   preferTorrent?: boolean;
+  prioritizeTasksWithTorrent?: boolean;
   skipExisting?: boolean;
   /** @format int32 */
   maxRetries?: number;

--- a/src/web/src/sdk/BApi2.d.ts
+++ b/src/web/src/sdk/BApi2.d.ts
@@ -7072,6 +7072,7 @@ export interface components {
             defaultPath?: string;
             namingConvention?: string;
             preferTorrent: boolean;
+            prioritizeTasksWithTorrent: boolean;
             skipExisting: boolean;
             /** Format: int32 */
             maxRetries: number;
@@ -7313,6 +7314,7 @@ export interface components {
             defaultPath?: string;
             namingConvention?: string;
             preferTorrent?: boolean;
+            prioritizeTasksWithTorrent?: boolean;
             skipExisting?: boolean;
             /** Format: int32 */
             maxRetries?: number;

--- a/src/web/src/sdk/constants.ts
+++ b/src/web/src/sdk/constants.ts
@@ -1896,17 +1896,20 @@ export const DownloaderStatusLabel: Record<DownloaderStatus, string> = {
 
 export enum DownloaderStopBy {
   ManuallyStop = 1,
-  AppendToTheQueue = 2
+  AppendToTheQueue = 2,
+  Defer = 3
 }
 
 export const downloaderStopBies = [
   { label: 'ManuallyStop', value: DownloaderStopBy.ManuallyStop },
-  { label: 'AppendToTheQueue', value: DownloaderStopBy.AppendToTheQueue }
+  { label: 'AppendToTheQueue', value: DownloaderStopBy.AppendToTheQueue },
+  { label: 'Defer', value: DownloaderStopBy.Defer }
 ] as const;
 
 export const DownloaderStopByLabel: Record<DownloaderStopBy, string> = {
   [DownloaderStopBy.ManuallyStop]: 'ManuallyStop',
-  [DownloaderStopBy.AppendToTheQueue]: 'AppendToTheQueue'
+  [DownloaderStopBy.AppendToTheQueue]: 'AppendToTheQueue',
+  [DownloaderStopBy.Defer]: 'Defer'
 };
 
 export enum DownloadTaskAction {


### PR DESCRIPTION
## What & why

Adds a downloader-level switch on the ExHentai config (right below **Prefer torrent**) that drains torrent-bearing tasks first when batch-downloading.

ExHentai tasks run **serially** (one per third-party at a time). Previously, if a couple of leading tasks had no torrent, they'd download images page-by-page (slow) and block dozens of torrent-bearing tasks from yielding their quick `.torrent` files. With this option on, the downloader grabs all the `.torrent` files first (so you can feed them to another tool), and downloads images for the torrent-less ones afterwards.

## How it works

- New global option `ExHentaiOptions.PrioritizeTasksWithTorrent` (default **off**, only meaningful while `PreferTorrent` is on; the checkbox is disabled otherwise).
- **Probe-then-defer (two phases)** for `SingleWork` tasks:
  - First pass on an un-probed, torrent-preferring task fetches the gallery detail. With a torrent → download the `.torrent` and complete. Without one → record an in-memory "no torrent" verdict and yield the slot back via a new `DownloaderStopBy.Defer` (`DownloadDeferredException`) — stays eligible, but kicks the scheduler to pick the next task immediately.
  - `TryStartAllTasks` orders ExHentai tasks so torrent-preferring/un-probed ones run before **image-only** ones (already probed with no torrent, **or** opting out of torrents via their own `PreferTorrent`). Once nothing torrent-bearing is left, the image-only tasks run and download images.
- **Per-task `PreferTorrent` is honored**: a task that opts out of torrents still downloads images — it just no longer holds up torrent-bearing tasks.
- A task's cached torrent verdict is **cleared when its options are edited** (`PutDownloadTask`), so flipping `PreferTorrent` re-probes on the next run.

## Notes

- The verdict lives only in `DownloaderManager` memory (cleared on terminal states), so it's rebuilt by re-probing after a restart — **no DB migration**.
- Scope: applies to **SingleWork** tasks only (List/Watched bundle many works, so "has a torrent" isn't a single yes/no).
- An already-running download is not interrupted; reordering takes effect once it finishes (or is stopped).
- Frontend: new checkbox in `ExHentaiConfig.tsx` + EN/CN locale strings; SDK regenerated for the new option and the `DownloaderStopBy.Defer` enum.

Closes #1201

---
_Generated by [Claude Code](https://claude.ai/code/session_01EAUhuS4ACa9bU4kd75cnDV)_