### PR TITLE
ci: run CI on PRs only and stop auto-deploying main on every merge

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -126,16 +126,19 @@ its `Closes #N` line to the commit for the change.
 
 ### Skip CI for docs / `.claude` changes
 
-`deploy.yml` ("Build and Deploy") has **no path filter** — any push to
-`main` / `debug-actions` / `release/v*` triggers a full build + OSS deploy +
-GitHub release, even for non-code changes.
+`deploy.yml` ("Build and Deploy") auto-runs **only on push to `release/v*`**
+— pushing a release branch is a deliberate publish. `main` / `debug-actions`
+are **not** auto-deployed; they deploy only via manual `workflow_dispatch`, so
+merging several PRs into `main` no longer fires a release per merge (batch
+them, then dispatch when ready). `ci.yml` runs only on PRs and is enforced as
+a required status check via branch protection, so the merge commit is never
+re-tested and deploy is no longer gated on CI.
 
-So for commits that touch **only** documentation, `.claude/**`, or other
-non-code files, add **`[skip ci]`** to the commit message. It skips the
-pipeline but does **not** affect `Closes #N` issue auto-closing.
-
-Do **not** skip CI for `.github/**` changes — CI/CD config edits should run
-the pipeline so the change itself gets validated.
+`[skip ci]` therefore only matters on the auto-deploy branch: add it to a
+commit you push to `release/v*` that touches **only** documentation,
+`.claude/**`, or other non-code files, to skip that release build. It does
+**not** affect `Closes #N` issue auto-closing. On `main` nothing auto-deploys,
+so the directive is moot there.
 
 ```
 docs: 更新 GitHub issue 管理工作流程 [skip ci]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,13 @@
 # Runs the test suites on every pull request. Independent of the
-# build/deploy pipeline (deploy.yml) so a broken test gates a PR
-# without touching releases.
+# build/deploy pipeline (deploy.yml): CI gates the PR — wire it up as a
+# required status check in branch protection so nothing reaches main
+# without passing — while deploy fires on the subsequent push to main.
+# Only PRs run CI; the merge commit is not re-tested (it was already
+# validated on the PR), which keeps deploy from re-running the suite.
 name: CI
 
 on:
   pull_request:
-  push:
-    # Mirror deploy.yml's branch list — deploy is gated on this workflow
-    # via `on: workflow_run`, so any branch that should auto-deploy must
-    # also run CI.
-    branches: [ main, debug-actions, 'release/v*' ]
   workflow_dispatch:
 
 # A newer push to the same branch / PR cancels older in-progress runs.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,22 +1,22 @@
 name: Build and Deploy
 
 on:
-  # Gate the pipeline on CI: only run after the CI workflow finishes on the
-  # same commit, and only proceed if it succeeded. PR runs are filtered out
-  # naturally — `branches:` here checks the run's head_branch, which for PRs
-  # is the feature branch (not main / release/* / debug-actions).
-  workflow_run:
-    workflows: [CI]
-    types: [completed]
-    branches: [ main, debug-actions, 'release/v*' ]
-  # Manual override: runs the full pipeline without waiting for CI, useful when
-  # CI is red for unrelated reasons or for commits whose push was [skip ci]'d.
+  # Auto-deploy only on the release branches — pushing a release/v* branch is a
+  # deliberate publish. main / debug-actions are NOT auto-deployed: merging
+  # several PRs into main shouldn't fire a release per merge, so batch them and
+  # publish via the manual workflow_dispatch below when ready.
+  # (CI no longer gates this; branch protection requires CI to pass before a PR
+  # can merge, so whatever lands here was already validated on the PR.)
+  push:
+    branches: [ 'release/v*' ]
+  # Manual trigger: deploy any ref on demand — main betas, debug-actions, or a
+  # re-deploy without a new commit. Pick the branch when dispatching.
   workflow_dispatch:
 
 # Don't cancel an in-progress deploy — OSS uploads + GitHub releases shouldn't
 # be torn down mid-flight. Serialize per target branch instead.
 concurrency:
-  group: deploy-${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.ref }}
+  group: deploy-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 permissions:
@@ -27,13 +27,6 @@ permissions:
 jobs:
   prepare:
     runs-on: ubuntu-latest
-    # Skip the entire pipeline unless CI succeeded on a push, or this is a
-    # manual dispatch. Without this guard, workflow_run fires on every CI
-    # completion regardless of outcome.
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.event == 'push')
     outputs:
       version: ${{ steps.set-var.outputs.version }}
       is_tag: ${{ steps.set-var.outputs.is_tag }}
@@ -41,17 +34,11 @@ jobs:
     steps:
       - name: Resolve target commit
         id: target
-        # workflow_run runs in the default-branch context — github.sha points
-        # at main's HEAD, not the commit CI actually validated. Pull the real
-        # SHA off the triggering run so build/deploy/release work on it.
+        # Both push and workflow_dispatch run in the context of the target
+        # commit itself, so github.ref / github.sha already point at it.
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "ref=${{ github.ref }}" >> $GITHUB_OUTPUT
-            echo "sha=${{ github.sha }}" >> $GITHUB_OUTPUT
-          else
-            echo "ref=refs/heads/${{ github.event.workflow_run.head_branch }}" >> $GITHUB_OUTPUT
-            echo "sha=${{ github.event.workflow_run.head_sha }}" >> $GITHUB_OUTPUT
-          fi
+          echo "ref=${{ github.ref }}" >> $GITHUB_OUTPUT
+          echo "sha=${{ github.sha }}" >> $GITHUB_OUTPUT
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -95,10 +82,6 @@ jobs:
           echo "github.event_name=${{ github.event_name }}"
           echo "github.ref=${{ github.ref }}"
           echo "github.sha=${{ github.sha }}"
-          echo "workflow_run.head_branch=${{ github.event.workflow_run.head_branch }}"
-          echo "workflow_run.head_sha=${{ github.event.workflow_run.head_sha }}"
-          echo "workflow_run.event=${{ github.event.workflow_run.event }}"
-          echo "workflow_run.conclusion=${{ github.event.workflow_run.conclusion }}"
           echo "resolved.ref=${{ steps.target.outputs.ref }}"
           echo "resolved.sha=${{ steps.target.outputs.sha }}"
           echo "resolved.version=${{ steps.set-var.outputs.version }}"


### PR DESCRIPTION
## What

Decouples CI from the deploy pipeline and stops `main` merges from each triggering a release.

- **`ci.yml`** — triggers only on `pull_request` (plus manual `workflow_dispatch`). The `push` trigger to `main` / `debug-actions` / `release/v*` is removed, so the merge commit is no longer re-tested. CI is meant to be enforced as a required status check via branch protection.
- **`deploy.yml`** — no longer gated on CI via `workflow_run`. It now auto-deploys **only** on push to `release/v*` (a deliberate publish). `main` / `debug-actions` deploy **only** via manual `workflow_dispatch`, so merging several PRs into `main` no longer fires a build + OSS deploy + GitHub release per merge — batch them and dispatch when ready. The `prepare` job is simplified to read `github.ref` / `github.sha` directly, since both `push` and `workflow_dispatch` run in the target commit's context.
- **`.claude/CLAUDE.md`** — updates the skip-ci section to reflect the new trigger model.

## Why

Previously CI ran twice per change (once on the PR, again on the push to `main` after merge, which gated deploy), and every merge to `main` produced a beta release. Both are wasteful when batching multiple PRs.

## Follow-up (manual, required)

This relies on **branch protection** to guarantee that code reaching `main` passed CI:

- On `main` (recommend also `release/v*`): enable *Require a pull request before merging*, *Require status checks to pass before merging* → select `Backend tests` and `Frontend lint & tests`, and *Require branches to be up to date before merging*.

Note: `release/v*` still auto-deploys on push while CI now runs only on PRs, so a direct push to a release branch would deploy without CI — protect it too if that matters.

Closes #1203

---
_Generated by [Claude Code](https://claude.ai/code/session_01KkGRY3vekz24Yhq6ZnAE1g)_