### PR TITLE
Add batch resource cache refresh with background task support

### DIFF
--- a/src/abstractions/Bakabase.Abstractions/Models/Input/RefreshResourcesCacheInputModel.cs
+++ b/src/abstractions/Bakabase.Abstractions/Models/Input/RefreshResourcesCacheInputModel.cs
@@ -1,0 +1,6 @@
+namespace Bakabase.Abstractions.Models.Input;
+
+public record RefreshResourcesCacheInputModel
+{
+    public int[] Ids { get; set; } = [];
+}

--- a/src/abstractions/Bakabase.Abstractions/Services/IResourceService.cs
+++ b/src/abstractions/Bakabase.Abstractions/Services/IResourceService.cs
@@ -113,6 +113,13 @@ public interface IResourceService
     /// </summary>
     Task<ResourceFileSystemCache?> RefreshResourceCache(int resourceId, CancellationToken ct);
 
+    /// <summary>
+    /// Refreshes the cache for many resources sequentially, reporting progress. Intended to be
+    /// driven from a background task so a large selection doesn't block a request.
+    /// </summary>
+    Task RefreshResourcesCache(IReadOnlyCollection<int> resourceIds, Func<int, string?, Task>? onProgress,
+        CancellationToken ct);
+
     Task MarkAsNotPlayed(int id);
 
     Task<Resource[]> GetAllGeneratedByMediaLibraryV2(int[]? ids = null, ResourceAdditionalItem additionalItems = ResourceAdditionalItem.None);

--- a/src/apps/Bakabase.Service/Controllers/CacheController.cs
+++ b/src/apps/Bakabase.Service/Controllers/CacheController.cs
@@ -1,7 +1,11 @@
-﻿using System.Threading;
+﻿using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
+using Bakabase.Abstractions.Components.Localization;
+using Bakabase.Abstractions.Components.Tasks;
 using Bakabase.Abstractions.Models.Domain;
 using Bakabase.Abstractions.Models.Domain.Constants;
+using Bakabase.Abstractions.Models.Input;
 using Bakabase.Abstractions.Models.View;
 using Bakabase.Abstractions.Services;
 using Bakabase.InsideWorld.Business.Models.Db;
@@ -10,15 +14,22 @@ using Bakabase.Service.Models.View;
 using Bootstrap.Components.Miscellaneous.ResponseBuilders;
 using Bootstrap.Components.Orm;
 using Bootstrap.Components.Orm.Infrastructures;
+using Bootstrap.Components.Tasks;
 using Bootstrap.Models.ResponseModels;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 using Swashbuckle.AspNetCore.Annotations;
 
 namespace Bakabase.Service.Controllers;
 
 [Route("~/cache")]
-public class CacheController(IResourceService resourceService) : Controller
+public class CacheController(
+    IResourceService resourceService,
+    BTaskManager taskManager,
+    IBakabaseLocalizer localizer) : Controller
 {
+    private const string RefreshResourcesCacheTaskId = "RefreshResourcesCache";
+
     [HttpGet]
     [SwaggerOperation(OperationId = "GetCacheOverview")]
     public async Task<SingletonResponse<CacheOverviewViewModel>> GetOverview()
@@ -65,5 +76,46 @@ public class CacheController(IResourceService resourceService) : Controller
     {
         var cache = await resourceService.RefreshResourceCache(resourceId, ct);
         return new SingletonResponse<ResourceFileSystemCache>(cache);
+    }
+
+    [HttpPost("resources/refresh")]
+    [SwaggerOperation(OperationId = "RefreshResourcesCache")]
+    public async Task<BaseResponse> RefreshResourcesCache([FromBody] RefreshResourcesCacheInputModel model)
+    {
+        var ids = model.Ids?.Distinct().ToArray() ?? [];
+        if (ids.Length == 0)
+        {
+            return BaseResponseBuilder.Ok;
+        }
+
+        // Refreshing a large selection scans the filesystem and regenerates thumbnails per
+        // resource, so run it as a cancellable background task instead of blocking the request.
+        await taskManager.Enqueue(
+            BTaskBuilder.Create(RefreshResourcesCacheTaskId)
+                .Named(() => localizer.BTask_Name(RefreshResourcesCacheTaskId))
+                .Describe(() => localizer.BTask_Description(RefreshResourcesCacheTaskId))
+                .OfResourceType(BTaskResourceType.Resource)
+                .ForResources(ids.Cast<object>().ToArray())
+                .ConflictsWith(RefreshResourcesCacheTaskId)
+                .Persistent()
+                .ReplaceIfExists()
+                .Run(async args =>
+                {
+                    await using var scope = args.RootServiceProvider.CreateAsyncScope();
+                    var service = scope.ServiceProvider.GetRequiredService<IResourceService>();
+                    await service.RefreshResourcesCache(
+                        ids,
+                        async (percentage, process) =>
+                        {
+                            await args.UpdateTask(t =>
+                            {
+                                t.Percentage = percentage;
+                                t.Process = process;
+                            });
+                        },
+                        args.CancellationToken);
+                }));
+
+        return BaseResponseBuilder.Ok;
     }
 }

--- a/src/legacy/Bakabase.InsideWorld.Business/Resources/SharedResource.resx
+++ b/src/legacy/Bakabase.InsideWorld.Business/Resources/SharedResource.resx
@@ -384,6 +384,12 @@ The version of lux is not limited.</value>
   <data name="BTask_Description_ResourceData" xml:space="preserve">
     <value>Prepare cover, playable item, and metadata data for all resources</value>
   </data>
+  <data name="BTask_Name_RefreshResourcesCache" xml:space="preserve">
+    <value>Refresh cache</value>
+  </data>
+  <data name="BTask_Description_RefreshResourcesCache" xml:space="preserve">
+    <value>Rebuild cover and playable item cache for the selected resources</value>
+  </data>
   <data name="BTask_MessageOnInterruption_MoveFiles" xml:space="preserve">
     <value>Some files are still in the process of being moved; forcibly interrupting may result in incomplete target files or folders.</value>
   </data>

--- a/src/legacy/Bakabase.InsideWorld.Business/Resources/SharedResource.zh-Hans.resx
+++ b/src/legacy/Bakabase.InsideWorld.Business/Resources/SharedResource.zh-Hans.resx
@@ -384,6 +384,12 @@
   <data name="BTask_Description_ResourceData" xml:space="preserve">
     <value>为所有资源准备封面、可播放项和元数据</value>
   </data>
+  <data name="BTask_Name_RefreshResourcesCache" xml:space="preserve">
+    <value>刷新缓存</value>
+  </data>
+  <data name="BTask_Description_RefreshResourcesCache" xml:space="preserve">
+    <value>为所选资源重建封面和可播放项缓存</value>
+  </data>
   <data name="BTask_MessageOnInterruption_MoveFiles" xml:space="preserve">
     <value>部分文件还在移动中，强制中断可能会导致目标文件或文件夹不完整</value>
   </data>

--- a/src/legacy/Bakabase.InsideWorld.Business/Services/ResourceProfileIndexService.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Services/ResourceProfileIndexService.cs
@@ -245,7 +245,7 @@ public class ResourceProfileIndexService : IResourceProfileIndexService
 
             if (resourcesToInvalidate.Count > 0)
             {
-                await ProcessResourceInvalidations(resourcesToInvalidate, resourceProfileService, args);
+                await ProcessResourceInvalidations(resourcesToInvalidate, resourceProfileService, resourceService, args);
             }
         }
         catch (Exception ex)
@@ -379,6 +379,11 @@ public class ResourceProfileIndexService : IResourceProfileIndexService
             _profilePriorities[profile.Id] = profile.Priority;
         }
 
+        // Resources touched by a profile add/edit/delete: their effective playable-file options
+        // may have changed (the profile gained/lost them, or its playable rules were edited), so
+        // any cached playable-file result must be invalidated to be re-discovered on next access.
+        var affectedResourceIds = new HashSet<int>();
+
         foreach (var profileId in profileIds)
         {
             args.CancellationToken.ThrowIfCancellationRequested();
@@ -389,6 +394,7 @@ public class ResourceProfileIndexService : IResourceProfileIndexService
                 foreach (var resourceId in oldResourceIds)
                 {
                     RemoveProfileFromResource(resourceId, profileId);
+                    affectedResourceIds.Add(resourceId);
                 }
             }
 
@@ -402,6 +408,7 @@ public class ResourceProfileIndexService : IResourceProfileIndexService
                 foreach (var resourceId in matchingResourceIds)
                 {
                     AddProfileToResource(resourceId, profileId);
+                    affectedResourceIds.Add(resourceId);
                 }
             }
             else
@@ -410,28 +417,44 @@ public class ResourceProfileIndexService : IResourceProfileIndexService
                 _profilePriorities.TryRemove(profileId, out _);
             }
         }
+
+        if (affectedResourceIds.Count > 0)
+        {
+            await resourceService.DeleteResourceCacheByResourceIdsAndCacheType(
+                affectedResourceIds, ResourceCacheType.PlayableFiles);
+        }
     }
 
     private async Task ProcessResourceInvalidations(
         HashSet<int> resourceIds,
         IResourceProfileService resourceProfileService,
+        IResourceService resourceService,
         BTaskArgs args)
     {
         _logger.LogDebug("Processing {Count} resource invalidations", resourceIds.Count);
 
         var allProfiles = await resourceProfileService.GetAll();
 
+        // Resources whose matching-profile set actually changed. Their effective playable-file
+        // options come from the highest-priority matching profile, so a change here can make a
+        // previously cached playable-file result stale. This is what lets a freshly-synced
+        // resource auto-recover: it may have been discovered with an empty playable result
+        // before it had been indexed against any profile (GetMatchingProfileIds returned none),
+        // which gets cached as a valid "no playable files" entry; once indexing catches up we
+        // invalidate that entry so the next access re-discovers from the (now resolvable) profile.
+        var matchingChangedResourceIds = new HashSet<int>();
+
         foreach (var resourceId in resourceIds)
         {
             args.CancellationToken.ThrowIfCancellationRequested();
 
             // Clear existing mappings for this resource
-            if (_resourceToProfiles.TryRemove(resourceId, out var oldProfileIds))
+            var oldProfileIds = _resourceToProfiles.TryRemove(resourceId, out var removed)
+                ? removed
+                : Array.Empty<int>();
+            foreach (var profileId in oldProfileIds)
             {
-                foreach (var profileId in oldProfileIds)
-                {
-                    RemoveResourceFromProfile(profileId, resourceId);
-                }
+                RemoveResourceFromProfile(profileId, resourceId);
             }
 
             // Re-evaluate against all profiles
@@ -468,6 +491,18 @@ public class ResourceProfileIndexService : IResourceProfileIndexService
                         .CompareTo(_profilePriorities.GetValueOrDefault(a, 0)));
                 _resourceToProfiles[resourceId] = matchingProfileIds;
             }
+
+            // Order-independent comparison of old vs new matching set.
+            if (!oldProfileIds.OrderBy(x => x).SequenceEqual(matchingProfileIds.OrderBy(x => x)))
+            {
+                matchingChangedResourceIds.Add(resourceId);
+            }
+        }
+
+        if (matchingChangedResourceIds.Count > 0)
+        {
+            await resourceService.DeleteResourceCacheByResourceIdsAndCacheType(
+                matchingChangedResourceIds, ResourceCacheType.PlayableFiles);
         }
     }
 

--- a/src/legacy/Bakabase.InsideWorld.Business/Services/ResourceService.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Services/ResourceService.cs
@@ -1600,6 +1600,43 @@ namespace Bakabase.InsideWorld.Business.Services
             return await GetResourceCache(resourceId);
         }
 
+        public async Task RefreshResourcesCache(IReadOnlyCollection<int> resourceIds,
+            Func<int, string?, Task>? onProgress, CancellationToken ct)
+        {
+            var ids = resourceIds.Distinct().ToList();
+            var total = ids.Count;
+            if (total == 0)
+            {
+                return;
+            }
+
+            var done = 0;
+            foreach (var id in ids)
+            {
+                ct.ThrowIfCancellationRequested();
+                try
+                {
+                    await RefreshResourceCache(id, ct);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception e)
+                {
+                    // One bad resource (missing path, unreadable file, ...) shouldn't abort the
+                    // whole batch — log and move on so the rest still get refreshed.
+                    _logger.LogError(e, "Failed to refresh cache for resource {ResourceId}", id);
+                }
+
+                done++;
+                if (onProgress != null)
+                {
+                    await onProgress((int) (done * 100f / total), $"{done}/{total}");
+                }
+            }
+        }
+
         public async Task MarkAsNotPlayed(int id)
         {
             await _orm.UpdateByKey(id, r => r.PlayedAt = null);

--- a/src/legacy/Bakabase.InsideWorld.Business/Services/ResourceService.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Services/ResourceService.cs
@@ -1556,6 +1556,22 @@ namespace Bakabase.InsideWorld.Business.Services
                 cache.PlayableFilePaths = null;
                 cache.CachedTypes &= ~ResourceCacheType.PlayableFiles;
 
+                // Persist the invalidation immediately so the nested Get(...) below doesn't see
+                // the previous CachedTypes flag and short-circuit to returning the stale cached
+                // playable files (LocalFilePlayableItemProvider.GetPlayableItemsAsync returns the
+                // cached paths — including a cached "empty" result — as soon as the PlayableFiles
+                // flag is set). Mirrors the cover branch above; without it, "refresh cache" can
+                // never re-discover playable files for a resource that was cached as empty.
+                if (isNew)
+                {
+                    await _resourceCacheOrm.Add(cache);
+                    isNew = false;
+                }
+                else
+                {
+                    await _resourceCacheOrm.Update(cache);
+                }
+
                 var playableProviders = GetRequiredService<IEnumerable<IPlayableItemProvider>>();
                 var localPlayableProvider = playableProviders.FirstOrDefault(p => p.Origin == DataOrigin.FileSystem);
                 var playableResource = await Get(resourceId, ResourceAdditionalItem.PlayableItem);

--- a/src/tests/Bakabase.Tests/LocalFilePlayableItemProviderCacheTests.cs
+++ b/src/tests/Bakabase.Tests/LocalFilePlayableItemProviderCacheTests.cs
@@ -203,6 +203,69 @@ public sealed class LocalFilePlayableItemProviderCacheTests
     }
 
     [TestMethod]
+    public async Task RefreshResourcesCache_RefreshesEverySelectedResource_AndReportsProgress()
+    {
+        // Two freshly-synced resources both cached as "no playable files"; the batch refresh must
+        // re-discover every one of them and report progress through to 100%.
+        foreach (var dirName in new[] { "Movie1", "Movie2" })
+        {
+            var dir = Path.Combine(_testRoot, dirName);
+            Directory.CreateDirectory(dir);
+            File.WriteAllBytes(Path.Combine(dir, "a.mp4"), Array.Empty<byte>());
+        }
+
+        await _sp.GetRequiredService<IPathMarkService>().Add(new PathMark
+        {
+            Path = _testRoot,
+            Type = PathMarkType.Resource,
+            ConfigJson = JsonConvert.SerializeObject(new ResourceMarkConfig
+            {
+                MatchMode = PathMatchMode.Layer,
+                Layer = 1,
+                FsTypeFilter = PathFilterFsType.Directory
+            }),
+            Priority = 100
+        });
+        await _sp.GetRequiredService<ResourceSyncService>().SyncResources(
+            ResourceSource.PathMark, null, null, new PauseToken(), CancellationToken.None);
+        await AddPlayableProfile("mp4");
+
+        var resources = (await _sp.GetRequiredService<IResourceService>().GetAll()).ToList();
+        Assert.AreEqual(2, resources.Count);
+
+        var cacheOrm = _sp
+            .GetRequiredService<FullMemoryCacheResourceService<BakabaseDbContext, ResourceCacheDbModel, int>>();
+        foreach (var r in resources)
+        {
+            await cacheOrm.Add(new ResourceCacheDbModel
+            {
+                ResourceId = r.Id,
+                CachedTypes = ResourceCacheType.PlayableFiles,
+                PlayableFilePaths = null
+            });
+        }
+
+        var lastPercentage = 0;
+        await _sp.GetRequiredService<IResourceService>().RefreshResourcesCache(
+            resources.Select(r => r.Id).ToList(),
+            (percentage, _) =>
+            {
+                lastPercentage = percentage;
+                return Task.CompletedTask;
+            },
+            CancellationToken.None);
+
+        Assert.AreEqual(100, lastPercentage);
+        foreach (var r in resources)
+        {
+            var cache = await GetCacheRow(r.Id);
+            Assert.IsNotNull(cache);
+            Assert.IsFalse(string.IsNullOrEmpty(cache!.PlayableFilePaths),
+                $"Batch refresh should have re-discovered the playable file for resource {r.Id}");
+        }
+    }
+
+    [TestMethod]
     public async Task InvalidateAsync_ClearsCacheFlag()
     {
         var resource = await SeedResource("Movie", "a.mp4");

--- a/src/tests/Bakabase.Tests/LocalFilePlayableItemProviderCacheTests.cs
+++ b/src/tests/Bakabase.Tests/LocalFilePlayableItemProviderCacheTests.cs
@@ -175,6 +175,34 @@ public sealed class LocalFilePlayableItemProviderCacheTests
     }
 
     [TestMethod]
+    public async Task RefreshResourceCache_RediscoversPlayableFiles_OverStaleEmptyCache()
+    {
+        // Regression: a resource was cached as "no playable files" (flag set, paths null) — e.g.
+        // discovered before it had been indexed against a playable profile. The file exists and a
+        // matching profile now exists. "Refresh cache" must re-discover it; previously it reloaded
+        // the stale cache via the nested Get and the provider short-circuited, re-saving empty.
+        var resource = await SeedResource("Movie", "a.mp4");
+        await AddPlayableProfile("mp4");
+
+        var cacheOrm = _sp
+            .GetRequiredService<FullMemoryCacheResourceService<BakabaseDbContext, ResourceCacheDbModel, int>>();
+        await cacheOrm.Add(new ResourceCacheDbModel
+        {
+            ResourceId = resource.Id,
+            CachedTypes = ResourceCacheType.PlayableFiles,
+            PlayableFilePaths = null
+        });
+
+        await _sp.GetRequiredService<IResourceService>().RefreshResourceCache(resource.Id, CancellationToken.None);
+
+        var cache = await GetCacheRow(resource.Id);
+        Assert.IsNotNull(cache);
+        Assert.IsTrue(cache!.CachedTypes.HasFlag(ResourceCacheType.PlayableFiles));
+        Assert.IsFalse(string.IsNullOrEmpty(cache.PlayableFilePaths),
+            "RefreshResourceCache should re-discover the playable file instead of keeping the stale empty cache");
+    }
+
+    [TestMethod]
     public async Task InvalidateAsync_ClearsCacheFlag()
     {
         var resource = await SeedResource("Movie", "a.mp4");

--- a/src/web/src/components/Resource/components/ContextMenuItems/index.tsx
+++ b/src/web/src/components/Resource/components/ContextMenuItems/index.tsx
@@ -42,6 +42,8 @@ type Props = {
   /** The resource whose context menu was triggered (may not be in selectedResources). */
   contextResource?: any;
   onSelectedResourcesChanged?: (ids: number[]) => any;
+  /** Called after resources are deleted so the parent can prune them from the list. */
+  onResourcesDeleted?: (ids: number[]) => any;
 };
 
 // ============================================================================
@@ -128,6 +130,7 @@ const ContextMenuItems = ({
   selectedResources,
   contextResource,
   onSelectedResourcesChanged,
+  onResourcesDeleted,
 }: Props) => {
   const { t } = useTranslation();
   const { createPortal } = useBakabaseContext();
@@ -427,6 +430,7 @@ const ContextMenuItems = ({
             ),
             onOk: async () => {
               await BApi.resource.bulkDeleteResources({ ids: selectedResourceIds, deleteFiles });
+              onResourcesDeleted?.(selectedResourceIds);
             },
           });
         }}

--- a/src/web/src/components/Resource/components/ContextMenuItems/index.tsx
+++ b/src/web/src/components/Resource/components/ContextMenuItems/index.tsx
@@ -317,6 +317,26 @@ const ContextMenuItems = ({
         })()}
 
       {/* Built-in menu items */}
+      {selectedResourceIds.length > 1 && (
+        <MenuItem
+          onClick={async () => {
+            // Runs as a background task server-side; a large selection would otherwise
+            // block while every resource is rescanned and its thumbnails regenerated.
+            const rsp = await BApi.cache.refreshResourcesCache({ ids: selectedResourceIds });
+
+            if (!rsp.code) {
+              toast.success(t<string>("resource.action.refreshCache.taskStarted"));
+            }
+          }}
+        >
+          <div className="flex items-center gap-2">
+            <ReloadOutlined className="text-base" />
+            {t<string>("resource.contextMenu.refreshCacheForCount", {
+              count: selectedResourceIds.length,
+            })}
+          </div>
+        </MenuItem>
+      )}
       <MenuItem
         onClick={() => {
           createPortal(MediaLibraryMultiSelector, {

--- a/src/web/src/components/Resource/components/Operations/index.tsx
+++ b/src/web/src/components/Resource/components/Operations/index.tsx
@@ -41,9 +41,10 @@ interface IProps {
   resource: Resource;
   coverRef?: IResourceCoverRef;
   reload?: (ct?: AbortSignal) => Promise<any>;
+  onResourcesDeleted?: (ids: number[]) => any;
 }
 
-const Operations = ({ resource, coverRef, reload }: IProps) => {
+const Operations = ({ resource, coverRef, reload, onResourcesDeleted }: IProps) => {
   const { t } = useTranslation();
   const { createPortal, createWindow } = useBakabaseContext();
   const uiOptions = useUiOptionsStore((state) => state.data);
@@ -154,7 +155,9 @@ const Operations = ({ resource, coverRef, reload }: IProps) => {
           ids: [resource.id],
           deleteFiles,
         });
-        reload?.();
+        // Prune the card from the list. reload?.() only re-fetches this single
+        // resource, which now returns nothing, leaving the deleted card visible.
+        onResourcesDeleted?.([resource.id]);
       },
     });
   };

--- a/src/web/src/components/Resource/index.tsx
+++ b/src/web/src/components/Resource/index.tsx
@@ -321,6 +321,8 @@ type Props = {
   selectedResourceIdsRef?: React.RefObject<number[]>;
   selectedResourcesRef?: React.RefObject<ResourceModel[]>;
   onSelectedResourcesChanged?: (ids: number[]) => any;
+  /** Called after resources are deleted so the parent can prune them from the list. */
+  onResourcesDeleted?: (ids: number[]) => any;
   debug?: boolean;
   /** Disable cover click to prevent opening DetailModal */
   disableCoverClick?: boolean;
@@ -341,6 +343,7 @@ const Resource = React.forwardRef((props: Props, ref) => {
     selectedResourceIdsRef,
     selectedResourcesRef,
     onSelectedResourcesChanged,
+    onResourcesDeleted,
     debug,
     disableCoverClick = false,
   } = props;
@@ -873,7 +876,12 @@ const Resource = React.forwardRef((props: Props, ref) => {
           <CheckCircleFilled className="text-primary text-xl drop-shadow-md" />
         </div>
       )}
-      <Operations coverRef={coverRef.current} reload={reload} resource={resource} />
+      <Operations
+        coverRef={coverRef.current}
+        reload={reload}
+        resource={resource}
+        onResourcesDeleted={onResourcesDeleted}
+      />
       <div
         onContextMenu={(e) => {
           if (typeof document.hasFocus === "function" && !document.hasFocus()) return;
@@ -903,6 +911,7 @@ const Resource = React.forwardRef((props: Props, ref) => {
               contextResource={resource}
               selectedResourceIds={selectedResourceIds}
               selectedResources={selectedResources}
+              onResourcesDeleted={onResourcesDeleted}
               onSelectedResourcesChanged={onSelectedResourcesChanged}
             />
           )}

--- a/src/web/src/hooks/useResourceSearch.ts
+++ b/src/web/src/hooks/useResourceSearch.ts
@@ -38,6 +38,8 @@ type UseResourceSearchResult = {
   setResources: React.Dispatch<React.SetStateAction<Resource[]>>;
   /** Reload specific resources by their IDs */
   reloadResources: (ids: number[]) => Promise<void>;
+  /** Remove resources from the list by their IDs (e.g. after deletion) */
+  removeResources: (ids: number[]) => void;
 };
 
 /**
@@ -242,6 +244,18 @@ export const useResourceSearch = (): UseResourceSearchResult => {
     }
   }, []);
 
+  // Drop resources from the list immediately after they are deleted. reloadResources
+  // can't do this: getResourcesByKeys returns nothing for deleted ids, and its
+  // `updatedMap.get(r.id) ?? r` fallback would keep the stale row in the list.
+  const removeResources = useCallback((ids: number[]) => {
+    if (ids.length === 0) {
+      return;
+    }
+    const idSet = new Set(ids);
+
+    setResources((prev) => prev.filter((r) => !idSet.has(r.id)));
+  }, []);
+
   return {
     resources,
     loading,
@@ -250,6 +264,7 @@ export const useResourceSearch = (): UseResourceSearchResult => {
     search,
     setResources,
     reloadResources,
+    removeResources,
   };
 };
 

--- a/src/web/src/locales/cn/components/resource.json
+++ b/src/web/src/locales/cn/components/resource.json
@@ -76,6 +76,7 @@
   "resource.action.refreshCache": "刷新缓存",
   "resource.action.refreshCache.success": "缓存已刷新",
   "resource.action.refreshCache.tooltip": "清空并重新创建此资源的缓存",
+  "resource.action.refreshCache.taskStarted": "刷新缓存任务已启动",
   "resource.operation.pin": "置顶",
   "resource.operation.unpin": "取消置顶",
   "resource.operation.enhancements": "增强",
@@ -85,6 +86,7 @@
   "Cover cache has been reset": "封面缓存已重置",
   "Reset cover cache of current resource": "重置当前资源的封面缓存",
 
+  "resource.contextMenu.refreshCacheForCount": "刷新 {{count}} 个资源的缓存",
   "resource.contextMenu.setMediaLibraries": "设置媒体库",
   "resource.contextMenu.setMediaLibrariesForCount": "为 {{count}} 个资源设置媒体库",
   "resource.contextMenu.transferResourceData": "转移资源数据",

--- a/src/web/src/locales/en/components/resource.json
+++ b/src/web/src/locales/en/components/resource.json
@@ -76,6 +76,7 @@
   "resource.action.refreshCache": "Refresh cache",
   "resource.action.refreshCache.success": "Cache refreshed",
   "resource.action.refreshCache.tooltip": "Clear and rebuild cache for this resource",
+  "resource.action.refreshCache.taskStarted": "Cache refresh task started",
   "resource.operation.pin": "Pin",
   "resource.operation.unpin": "Unpin",
   "resource.operation.enhancements": "Enhancements",
@@ -85,6 +86,7 @@
   "Cover cache has been reset": "Cover cache has been reset",
   "Reset cover cache of current resource": "Reset cover cache of current resource",
 
+  "resource.contextMenu.refreshCacheForCount": "Refresh cache for {{count}} resources",
   "resource.contextMenu.setMediaLibraries": "Set media libraries",
   "resource.contextMenu.setMediaLibrariesForCount": "Set media libraries for {{count}} resources",
   "resource.contextMenu.transferResourceData": "Transfer resource data",

--- a/src/web/src/pages/resource/components/ResourceTabContent.tsx
+++ b/src/web/src/pages/resource/components/ResourceTabContent.tsx
@@ -67,6 +67,7 @@ const ResourceTabContent = React.forwardRef<ResourceTabContentRef, Props>((props
     response: searchResponse,
     search: progressiveSearch,
     reloadResources,
+    removeResources,
   } = useResourceSearch();
   const resourcesRef = useRef(resources);
   // Deferred resources keep the heavy grid render low-priority so filter edits stay responsive.
@@ -491,6 +492,21 @@ const ResourceTabContent = React.forwardRef<ResourceTabContentRef, Props>((props
     [reloadResources],
   );
 
+  // Prune deleted resources from the grid immediately (and drop them from the
+  // current selection) so the card disappears without waiting for a re-search.
+  const onResourcesDeleted = useCallback(
+    (ids: number[]) => {
+      if (ids.length === 0) {
+        return;
+      }
+      removeResources(ids);
+      const idSet = new Set(ids);
+
+      setSelectedIds((prev) => prev.filter((id) => !idSet.has(id)));
+    },
+    [removeResources],
+  );
+
   type GridCellRenderArgs = {
     columnIndex: number;
     key: string;
@@ -532,13 +548,14 @@ const ResourceTabContent = React.forwardRef<ResourceTabContentRef, Props>((props
             selectedResourceIdsRef={selectedIdsRef}
             selectedResourcesRef={selectedResourcesRef}
             selectionModeRef={multiSelectionRef}
+            onResourcesDeleted={onResourcesDeleted}
             onSelected={onSelect}
             onSelectedResourcesChanged={onSelectedResourcesChanged}
           />
         </div>
       );
     },
-    [displayResources, columnCount, onSelect, onSelectedResourcesChanged],
+    [displayResources, columnCount, onSelect, onSelectedResourcesChanged, onResourcesDeleted],
   );
 
   useImperativeHandle(ref, () => ({

--- a/src/web/src/sdk/Api.ts
+++ b/src/web/src/sdk/Api.ts
@@ -916,6 +916,10 @@ export interface BakabaseAbstractionsModelsInputPathMarkPreviewRequest {
   configJson: string;
 }
 
+export interface BakabaseAbstractionsModelsInputRefreshResourcesCacheInputModel {
+  ids: number[];
+}
+
 export interface BakabaseAbstractionsModelsInputResourceMergeInputModel {
   /** @format int32 */
   targetResourceId: number;
@@ -9565,6 +9569,37 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         format: "json",
         ...params,
       }),
+
+    /**
+     * No description
+     *
+     * @tags Cache
+     * @name RefreshResourcesCache
+     * @request POST:/cache/resources/refresh
+     */
+    refreshResourcesCache: (
+      data: BakabaseAbstractionsModelsInputRefreshResourcesCacheInputModel,
+      params: RequestParams = {},
+    ) =>
+      this.request<BootstrapModelsResponseModelsBaseResponse, any>({
+        path: `/cache/resources/refresh`,
+        method: "POST",
+        body: data,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Build URL for refreshResourcesCache
+     * @name refreshResourcesCacheUrl
+     */
+    refreshResourcesCacheUrl: () => {
+      const baseUrl = this.baseUrl || "";
+      let path = `/cache/resources/refresh`;
+      
+      return baseUrl + path;
+    },
   };
   chat = {
     /**

--- a/src/web/src/sdk/BApi2.d.ts
+++ b/src/web/src/sdk/BApi2.d.ts
@@ -1060,6 +1060,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/cache/resources/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["RefreshResourcesCache"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/chat/conversations": {
         parameters: {
             query?: never;
@@ -6740,6 +6756,9 @@ export interface components {
             path: string;
             type: components["schemas"]["Bakabase.Abstractions.Models.Domain.Constants.PathMarkType"];
             configJson: string;
+        };
+        "Bakabase.Abstractions.Models.Input.RefreshResourcesCacheInputModel": {
+            ids: number[];
         };
         "Bakabase.Abstractions.Models.Input.ResourceMergeInputModel": {
             /** Format: int32 */
@@ -13959,6 +13978,35 @@ export interface operations {
                     "text/plain": components["schemas"]["Bootstrap.Models.ResponseModels.SingletonResponse`1[Bakabase.Abstractions.Models.Domain.ResourceFileSystemCache]"];
                     "application/json": components["schemas"]["Bootstrap.Models.ResponseModels.SingletonResponse`1[Bakabase.Abstractions.Models.Domain.ResourceFileSystemCache]"];
                     "text/json": components["schemas"]["Bootstrap.Models.ResponseModels.SingletonResponse`1[Bakabase.Abstractions.Models.Domain.ResourceFileSystemCache]"];
+                };
+            };
+        };
+    };
+    RefreshResourcesCache: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json-patch+json": components["schemas"]["Bakabase.Abstractions.Models.Input.RefreshResourcesCacheInputModel"];
+                "application/json": components["schemas"]["Bakabase.Abstractions.Models.Input.RefreshResourcesCacheInputModel"];
+                "text/json": components["schemas"]["Bakabase.Abstractions.Models.Input.RefreshResourcesCacheInputModel"];
+                "application/*+json": components["schemas"]["Bakabase.Abstractions.Models.Input.RefreshResourcesCacheInputModel"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": components["schemas"]["Bootstrap.Models.ResponseModels.BaseResponse"];
+                    "application/json": components["schemas"]["Bootstrap.Models.ResponseModels.BaseResponse"];
+                    "text/json": components["schemas"]["Bootstrap.Models.ResponseModels.BaseResponse"];
                 };
             };
         };


### PR DESCRIPTION
## Summary

Adds a new batch cache refresh feature that allows users to refresh the cache for multiple resources simultaneously via a background task, preventing large selections from blocking the HTTP request. Also fixes a regression where stale empty playable-file caches could not be re-discovered.

## Key Changes

- **New API endpoint** (`POST /cache/resources/refresh`): Accepts a list of resource IDs and enqueues a background task to refresh their caches sequentially with progress reporting.

- **Batch refresh service method** (`IResourceService.RefreshResourcesCache`): Processes multiple resources with error resilience (one bad resource doesn't abort the batch) and optional progress callback.

- **Cache invalidation fix**: When invalidating playable-file cache during `RefreshResourceCache`, the invalidation is now persisted immediately before re-discovery. This prevents the nested `Get(...)` call from short-circuiting on the stale cached flag and re-saving the empty result.

- **Profile-driven cache invalidation**: When resource profiles are added/edited/deleted, affected resources' playable-file caches are now invalidated. When a resource's matching-profile set changes (e.g., after indexing catches up), its playable-file cache is invalidated so the next access re-discovers from the newly-available profile.

- **UI enhancements**:
  - Context menu item for batch refresh (visible when 2+ resources selected)
  - Immediate removal of deleted resources from the grid without waiting for re-search
  - Progress tracking via background task system

- **Test coverage**: Two new regression tests verify that stale empty caches are re-discovered on refresh, both for single and batch operations.

- **Localization**: Added English and Chinese strings for the new task and UI elements.

## Implementation Details

- The background task runs sequentially through each resource ID, catching and logging exceptions per-resource to ensure the batch completes even if individual resources fail.
- Progress is reported as `(percentage, "done/total")` to the task manager for UI display.
- Cache invalidation is order-independent: resources are only marked for invalidation if their matching-profile set actually changed, not just reordered.
- The fix mirrors the existing cover-cache invalidation pattern to ensure consistency.

https://claude.ai/code/session_01L3vo9qnAZSRPjUkG8tZvWU