### PR TITLE
docs: scope sentry-triage skill to bakabase-web and bakabase-service

### DIFF
--- a/.claude/skills/sentry-triage/SKILL.md
+++ b/.claude/skills/sentry-triage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-triage
-description: Pull all unresolved issues from Sentry (bakabase.sentry.io), triage each, reuse or create concise Chinese GitHub issues with labels, fix them on a feature branch, and open a PR that auto-closes those issues. Use when the user asks to process, triage, or fix Sentry issues / production errors.
+description: Pull unresolved issues from Sentry (bakabase.sentry.io) for the bakabase-web and bakabase-service projects, triage each, reuse or create concise Chinese GitHub issues with labels, fix them on a feature branch, and open a PR that auto-closes those issues. Use when the user asks to process, triage, or fix Sentry issues / production errors.
 ---
 
 # Sentry Issue Triage Workflow
@@ -43,11 +43,13 @@ Sentry org slug: `bakabase`. API base: `https://bakabase.sentry.io/api/0`.
 Authenticate every request with the header
 `Authorization: Bearer <BAKABASE_SENTRY_PAT>`.
 
-1. List projects: `GET /organizations/bakabase/projects/`.
-2. For each project, list unresolved issues — follow `Link`-header cursor
-   pagination until exhausted:
+Scope: only the projects `bakabase-web` and `bakabase-service`. Do **not**
+list or scan any other project in the org.
+
+1. For each of the two project slugs, list unresolved issues — follow
+   `Link`-header cursor pagination until exhausted:
    `GET /projects/bakabase/<project-slug>/issues/?query=is%3Aunresolved&sort=freq&limit=100`
-3. For each issue, fetch the latest event for its stack trace:
+2. For each issue, fetch the latest event for its stack trace:
    `GET /issues/<issueId>/events/latest/`
 
 From each issue keep `shortId`, `title`, `culprit`, `level`, `count`,


### PR DESCRIPTION
## Summary
Updated the sentry-triage skill documentation to explicitly scope Sentry issue retrieval to only the `bakabase-web` and `bakabase-service` projects, rather than scanning all projects in the organization.

## Changes
- Updated skill description to clarify that only `bakabase-web` and `bakabase-service` projects are processed
- Added explicit scope constraint in the API workflow section to prevent scanning other projects
- Simplified the API workflow steps by removing the "list all projects" step and directly iterating over the two target project slugs
- Renumbered subsequent steps for clarity

## Rationale
This change prevents the skill from inadvertently processing issues from unrelated projects in the Sentry organization, ensuring focused and efficient triage of only the relevant production services.

https://claude.ai/code/session_013G1ShTU3Tu14FNFkcPp6AW