### PR TITLE
feat(web): allow dismissing the failed app-update banner for the current run

### DIFF
--- a/src/web/src/layouts/BasicLayout/components/AppUpdateBanner/index.tsx
+++ b/src/web/src/layouts/BasicLayout/components/AppUpdateBanner/index.tsx
@@ -4,7 +4,7 @@ import type { BakabaseInfrastructuresComponentsAppUpgradeAbstractionsAppVersionI
 
 import React, { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { ReloadOutlined, WarningOutlined } from "@ant-design/icons";
+import { CloseOutlined, ReloadOutlined, WarningOutlined } from "@ant-design/icons";
 
 import { Button, Progress, Spinner, Tooltip } from "@/components/bakaui";
 import BApi from "@/sdk/BApi";
@@ -23,6 +23,7 @@ interface ViewProps {
   state: AppUpdateBannerViewState;
   onRestart: () => void;
   onRetry: () => void;
+  onDismiss: () => void;
 }
 
 // Mirrors HeroUI `Button size="sm" variant="bordered"` so the checking and
@@ -35,6 +36,7 @@ export const AppUpdateBannerView: React.FC<ViewProps> = ({
   state,
   onRestart,
   onRetry,
+  onDismiss,
 }) => {
   const { t } = useTranslation();
 
@@ -88,18 +90,38 @@ export const AppUpdateBannerView: React.FC<ViewProps> = ({
   if (state.kind === "failed") {
     return (
       <div className={wrapperClass}>
-        <Tooltip
-          content={`${t<string>("appUpdate.failed")} ${state.error ? `(${t(state.error)})` : ""}`}
-          isDisabled={!collapsed}
-          placement="right"
-        >
-          <Button color="danger" isIconOnly={collapsed} size="sm" variant="flat" onPress={onRetry}>
-            <WarningOutlined />
-            {!collapsed && (
-              <span className={labelClass}>{t<string>("appUpdate.clickToRetry")}</span>
-            )}
-          </Button>
-        </Tooltip>
+        <div className={`flex items-center gap-1 ${collapsed ? "flex-col" : "justify-between"}`}>
+          <Tooltip
+            content={`${t<string>("appUpdate.failed")} ${state.error ? `(${t(state.error)})` : ""}`}
+            isDisabled={!collapsed}
+            placement="right"
+          >
+            <Button
+              aria-label={t<string>("appUpdate.clickToRetry")}
+              color="danger"
+              isIconOnly={collapsed}
+              size="sm"
+              variant="flat"
+              onPress={onRetry}
+            >
+              <WarningOutlined />
+              {!collapsed && (
+                <span className={labelClass}>{t<string>("appUpdate.clickToRetry")}</span>
+              )}
+            </Button>
+          </Tooltip>
+          <Tooltip content={t<string>("appUpdate.dismiss")} placement="right">
+            <Button
+              aria-label={t<string>("appUpdate.dismiss")}
+              isIconOnly
+              size="sm"
+              variant="light"
+              onPress={onDismiss}
+            >
+              <CloseOutlined />
+            </Button>
+          </Tooltip>
+        </div>
       </div>
     );
   }
@@ -180,7 +202,11 @@ const AppUpdateBanner: React.FC<Props> = ({ collapsed }) => {
   } else if (status === UpdaterStatus.PendingRestart) {
     viewState = { kind: "pendingRestart" };
   } else if (status === UpdaterStatus.Failed) {
-    viewState = { kind: "failed", error: appUpdaterState.error };
+    // Let the user dismiss the failed banner for the current run so a transient
+    // network failure doesn't leave a persistent warning icon in the sidebar.
+    viewState = appUpdaterState.failureDismissed
+      ? { kind: "hidden" }
+      : { kind: "failed", error: appUpdaterState.error };
   } else if (
     status === UpdaterStatus.Running ||
     (hasNewVersion && status !== UpdaterStatus.UpToDate)
@@ -198,6 +224,7 @@ const AppUpdateBanner: React.FC<Props> = ({ collapsed }) => {
     <AppUpdateBannerView
       collapsed={collapsed}
       state={viewState}
+      onDismiss={() => appUpdaterState.dismissFailure()}
       onRestart={() => BApi.updater.restartAndUpdateApp()}
       onRetry={() => BApi.updater.startUpdatingApp()}
     />

--- a/src/web/src/locales/cn/common.json
+++ b/src/web/src/locales/cn/common.json
@@ -4,6 +4,7 @@
   "appUpdate.restartToUpdate": "点击重启更新",
   "appUpdate.failed": "更新失败",
   "appUpdate.clickToRetry": "点击重试",
+  "appUpdate.dismiss": "本次运行内不再提示",
   "common.enabled": "已启用",
   "common.disabled": "已禁用",
   "Close": "关闭",

--- a/src/web/src/locales/en/common.json
+++ b/src/web/src/locales/en/common.json
@@ -4,6 +4,7 @@
   "appUpdate.restartToUpdate": "Click to restart and update",
   "appUpdate.failed": "Update failed",
   "appUpdate.clickToRetry": "Click to retry",
+  "appUpdate.dismiss": "Dismiss until next launch",
   "common.enabled": "Enabled",
   "common.disabled": "Disabled",
   "Close": "Close",

--- a/src/web/src/pages/test/cases/AppUpdateBannerTest.tsx
+++ b/src/web/src/pages/test/cases/AppUpdateBannerTest.tsx
@@ -50,6 +50,7 @@ const AppUpdateBannerTest = () => {
               <AppUpdateBannerView
                 collapsed={collapsed}
                 state={c.state}
+                onDismiss={() => console.log("dismiss")}
                 onRestart={() => console.log("restart")}
                 onRetry={() => console.log("retry")}
               />

--- a/src/web/src/stores/appUpdaterState.ts
+++ b/src/web/src/stores/appUpdaterState.ts
@@ -1,4 +1,4 @@
-import type { UpdaterStatus } from "@/sdk/constants";
+import { UpdaterStatus } from "@/sdk/constants";
 
 import { create } from "zustand";
 
@@ -6,12 +6,28 @@ interface AppUpdaterState {
   status?: UpdaterStatus;
   percentage?: number;
   error?: string;
-  update: (payload: Partial<Omit<AppUpdaterState, "update">>) => void;
+  // Whether the user dismissed the failed-update banner for the current run.
+  // In-memory only: a page reload / app restart resets it back to false.
+  failureDismissed: boolean;
+  update: (payload: Partial<Omit<AppUpdaterState, "update" | "dismissFailure">>) => void;
+  dismissFailure: () => void;
 }
 
 export const useAppUpdaterStateStore = create<AppUpdaterState>((set, get) => ({
   status: undefined,
   percentage: undefined,
   error: undefined,
-  update: (payload) => set((state) => ({ ...state, ...payload })),
+  failureDismissed: false,
+  update: (payload) =>
+    set((state) => {
+      // A fresh, non-failed status means a new update cycle started, so a
+      // previously dismissed failure should surface again if it fails anew.
+      const failureDismissed =
+        payload.status !== undefined && payload.status !== UpdaterStatus.Failed
+          ? false
+          : state.failureDismissed;
+
+      return { ...state, ...payload, failureDismissed };
+    }),
+  dismissFailure: () => set({ failureDismissed: true }),
 }));


### PR DESCRIPTION
## Problem

When the app updater reports `UpdaterStatus.Failed` (e.g. a transient network error while checking for or downloading an update), the bottom-left sidebar keeps showing a warning icon + "click to retry" for the whole session. Users reported this persistent warning as visually noisy.

Note: a network failure during the *initial* version check already falls through to a hidden state — the stuck warning is specifically the updater-reported `Failed` state pushed over SignalR.

## Change

Add a close button to the failed update banner that hides it for the current run.

- **In-memory only**: the dismissal lives in the `appUpdaterState` store and resets on page reload / app relaunch — matching the "dismiss for this run" intent.
- **Doesn't mute genuine new failures**: when a fresh, non-`Failed` status arrives (e.g. a retry pushes `Running`), the dismiss flag auto-resets, so a subsequent failure resurfaces the banner.
- Scope is limited to the sidebar banner; the settings page (AppInfo) still shows the true updater status, since that's an intentional diagnostic view.

## Files

| File | Change |
|---|---|
| `stores/appUpdaterState.ts` | Add `failureDismissed` + `dismissFailure()`; `update()` auto-resets the flag on any non-`Failed` status |
| `layouts/BasicLayout/components/AppUpdateBanner/index.tsx` | Close button on the failed state; `Failed && failureDismissed → hidden`; also adds an `aria-label` to the retry button and right-aligns the dismiss button |
| `locales/{en,cn}/common.json` | New `appUpdate.dismiss` key ("Dismiss until next launch" / "本次运行内不再提示") |
| `pages/test/cases/AppUpdateBannerTest.tsx` | Thread the new `onDismiss` prop |

## Notes

- No SDK/enum changes, so `gen-sdk` was not required.
- `node_modules` is not installed in this environment, so `tsc`/`eslint` were not run here; the change was reviewed statically for type-safety, logic, and UX/i18n consistency.

Closes #1218

---
_Generated by [Claude Code](https://claude.ai/code/session_018QEenMpt5Lw93mnetz6Ait)_