### PR TITLE
fix: batch triage of unresolved Sentry issues

### DIFF
--- a/src/abstractions/Bakabase.Abstractions/Exceptions/IUserActionableException.cs
+++ b/src/abstractions/Bakabase.Abstractions/Exceptions/IUserActionableException.cs
@@ -1,0 +1,20 @@
+namespace Bakabase.Abstractions.Exceptions
+{
+    /// <summary>
+    /// Marks an exception that reports a condition the *user* has to resolve — a dependency
+    /// that is not installed yet, an expired third-party cookie, a path that does not exist —
+    /// rather than a defect in Bakabase.
+    ///
+    /// These are surfaced to the user through the normal error channels (controller response,
+    /// task error message), but they are deliberately dropped before reaching the error
+    /// dashboard: they are not actionable for us, and in aggregate they drown out real crashes.
+    /// See the <c>SetBeforeSend</c> filter in <c>BakabaseStartup</c>.
+    ///
+    /// Implement this on the exception type instead of adding another special case to that
+    /// filter — the filter walks the whole <see cref="System.Exception.InnerException"/> chain,
+    /// so a wrapped instance is dropped too.
+    /// </summary>
+    public interface IUserActionableException
+    {
+    }
+}

--- a/src/apps/Bakabase.Service/Components/BakabaseStartup.cs
+++ b/src/apps/Bakabase.Service/Components/BakabaseStartup.cs
@@ -3,6 +3,7 @@ using Bakabase.Abstractions.Components.Configuration;
 using Bakabase.Abstractions.Components.Localization;
 using Bakabase.Abstractions.Components.Network;
 using Bakabase.Abstractions.Components.Tasks;
+using Bakabase.Abstractions.Exceptions;
 using Bakabase.Abstractions.Extensions;
 using Bakabase.Abstractions.Services;
 using Bakabase.Infrastructures.Components.App;
@@ -237,11 +238,12 @@ namespace Bakabase.Service.Components
                             {
                                 return null;
                             }
-                            // Expected: dependency (7-Zip / ffmpeg / lux / …)
-                            // not yet installed — the UI prompts the user to
-                            // install it, this is not a defect.
-                            if (ex is Bakabase.InsideWorld.Business.Components.Dependency.Exceptions
-                                .DependencyNotInstalledException)
+                            // Conditions the user resolves themselves — a dependency
+                            // (7-Zip / ffmpeg / lux / …) not installed yet, an expired
+                            // DLsite cookie, … Bakabase already surfaces these in the
+                            // UI; they are not defects. Mark the exception type with
+                            // IUserActionableException instead of adding a case here.
+                            if (ex is IUserActionableException)
                             {
                                 return null;
                             }

--- a/src/apps/Bakabase.Service/Controllers/FileController.cs
+++ b/src/apps/Bakabase.Service/Controllers/FileController.cs
@@ -900,18 +900,15 @@ namespace Bakabase.Service.Controllers
             return BaseResponseBuilder.Ok;
         }
 
-        [HttpPost("move-entries")]
-        [SwaggerOperation(OperationId = "MoveEntries")]
-        public async Task<BaseResponse> MoveEntries([FromBody] FileMoveRequestModel model)
+        /// <summary>
+        /// Reject copying/moving a directory into its own subtree up-front, instead of letting the
+        /// BTask blow up later with an Exception that lands in Sentry — and giving the user a 400
+        /// they can act on. DirectoryUtils runs its own check for safety; this one is stricter about
+        /// the separator boundary, so <c>D:\A\Book</c> → <c>D:\A\Book2</c> is correctly allowed here.
+        /// </summary>
+        private static BaseResponse? RejectNestedDestination(string[] paths, string destDir, string verb)
         {
-            var paths = model.EntryPaths.FindTopLevelPaths();
-            // Directory.CreateDirectory(model.DestDir);
-
-            // Reject moving a folder into its own subtree up-front, instead of
-            // letting the BTask blow up later with an Exception that lands in
-            // Sentry. The same check runs again inside DirectoryUtils.MoveAsync
-            // for safety, but catching it here also gives the user a 400.
-            var normalizedDest = Path.GetFullPath(model.DestDir).TrimEnd(
+            var normalizedDest = Path.GetFullPath(destDir).TrimEnd(
                 Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
             foreach (var path in paths)
             {
@@ -922,8 +919,24 @@ namespace Bakabase.Service.Controllers
                         StringComparison.OrdinalIgnoreCase))
                 {
                     return BaseResponseBuilder.BuildBadRequest(
-                        $"Cannot move '{path}' into its own subdirectory '{model.DestDir}'.");
+                        $"Cannot {verb} '{path}' into its own subdirectory '{destDir}'.");
                 }
+            }
+
+            return null;
+        }
+
+        [HttpPost("move-entries")]
+        [SwaggerOperation(OperationId = "MoveEntries")]
+        public async Task<BaseResponse> MoveEntries([FromBody] FileMoveRequestModel model)
+        {
+            var paths = model.EntryPaths.FindTopLevelPaths();
+            // Directory.CreateDirectory(model.DestDir);
+
+            var nested = RejectNestedDestination(paths, model.DestDir, "move");
+            if (nested != null)
+            {
+                return nested;
             }
 
             await _fsOptionsManager.SaveAsync(options =>
@@ -980,6 +993,12 @@ namespace Bakabase.Service.Controllers
         public async Task<BaseResponse> CopyEntries([FromBody] FileMoveRequestModel model)
         {
             var paths = model.EntryPaths.FindTopLevelPaths();
+
+            var nested = RejectNestedDestination(paths, model.DestDir, "copy");
+            if (nested != null)
+            {
+                return nested;
+            }
 
             await _fsOptionsManager.SaveAsync(options =>
             {

--- a/src/apps/Bakabase/Bakabase.csproj
+++ b/src/apps/Bakabase/Bakabase.csproj
@@ -11,9 +11,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.3.0" />
-        <PackageReference Include="Avalonia.Desktop" Version="11.3.0" />
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.0" />
+        <PackageReference Include="Avalonia" Version="11.3.20" />
+        <PackageReference Include="Avalonia.Desktop" Version="11.3.20" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.20" />
         <PackageReference Include="HttpCloak" Version="1.6.1" />
         <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3856.49" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
         <PackageReference Include="Velopack" Version="0.0.1298" />

--- a/src/apps/Bakabase/Components/AvaloniaGuiAdapter.cs
+++ b/src/apps/Bakabase/Components/AvaloniaGuiAdapter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
@@ -46,15 +47,37 @@ public class AvaloniaGuiAdapter : GuiAdapter, ITrayIconController
     public override T InvokeInGuiContext<T>(Func<T> func) =>
         Dispatcher.UIThread.Invoke(func);
 
+    /// <summary>
+    /// Cached one per state. BTaskManager flips its running flag whenever any task starts or
+    /// finishes, so this is called constantly; building a fresh <see cref="WindowIcon"/> each time
+    /// re-decoded the .ico and — on Avalonia before 11.3.8, which had no finalizer on Win32Icon —
+    /// leaked a GDI handle per call until the process ran out and tray interactions started
+    /// failing. Two long-lived icons and an early-out on "no change" keep that churn at zero.
+    /// </summary>
+    private readonly Dictionary<bool, WindowIcon> _trayIcons = new();
+    private bool? _trayIconIsRunning;
+
     public void SetTrayIcon(bool isRunning)
     {
         Dispatcher.UIThread.Invoke(() =>
         {
+            if (_trayIconIsRunning == isRunning)
+            {
+                return;
+            }
+
             try
             {
-                var assetName = isRunning ? "tray-running" : "favicon";
-                _app.AppTrayIcon.Icon = new WindowIcon(
-                    AssetLoader.Open(new Uri($"avares://Bakabase/Assets/{assetName}.ico")));
+                if (!_trayIcons.TryGetValue(isRunning, out var icon))
+                {
+                    var assetName = isRunning ? "tray-running" : "favicon";
+                    icon = new WindowIcon(
+                        AssetLoader.Open(new Uri($"avares://Bakabase/Assets/{assetName}.ico")));
+                    _trayIcons[isRunning] = icon;
+                }
+
+                _app.AppTrayIcon.Icon = icon;
+                _trayIconIsRunning = isRunning;
             }
             catch (System.ComponentModel.Win32Exception)
             {

--- a/src/apps/Bakabase/Controls/NativeWebViewHost.Windows.cs
+++ b/src/apps/Bakabase/Controls/NativeWebViewHost.Windows.cs
@@ -333,6 +333,25 @@ public partial class NativeWebViewHost
         }
     }
 
+    /// <summary>
+    /// Push the current client size into the WebView2 controller.
+    ///
+    /// This runs from the SizeChanged handler, i.e. inside Avalonia's layout pass, so anything
+    /// escaping here takes down the window being laid out — including the initial layout pass of
+    /// <c>Window.Show()</c>, which is how it reached users: re-opening the main window from the
+    /// tray after the WebView2 controller had died crashed the app.
+    ///
+    /// A non-null check cannot pre-empt it. WebView2 fails this call in two ways we only learn
+    /// about by making it:
+    ///   * <see cref="InvalidOperationException"/> — the controller was disposed out from under
+    ///     us (e.g. the browser process died while the window was hidden). It never recovers, so
+    ///     we drop our references and stop driving it.
+    ///   * <see cref="COMException"/> 0x8007139F (ERROR_INVALID_STATE) — alive, but not currently
+    ///     in a state that accepts a bounds change. Transient; the next size change retries.
+    ///
+    /// Both arrive wrapped in a <see cref="System.Reflection.TargetInvocationException"/> because
+    /// the property is set reflectively.
+    /// </summary>
     private void ResizeWebView2()
     {
         if (_winController == null || _winHwnd == IntPtr.Zero) return;
@@ -341,12 +360,29 @@ public partial class NativeWebViewHost
 
         // controller.Bounds = new Rectangle(0, 0, width, height)
         var boundsProperty = _winController.GetType().GetProperty("Bounds");
-        if (boundsProperty != null)
+        if (boundsProperty == null) return;
+
+        // CoreWebView2Controller.Bounds uses System.Drawing.Rectangle
+        var rectType = boundsProperty.PropertyType;
+        var rectInstance = Activator.CreateInstance(rectType, 0, 0, rect.Right, rect.Bottom);
+        try
         {
-            // CoreWebView2Controller.Bounds uses System.Drawing.Rectangle
-            var rectType = boundsProperty.PropertyType;
-            var rectInstance = Activator.CreateInstance(rectType, 0, 0, rect.Right, rect.Bottom);
             boundsProperty.SetValue(_winController, rectInstance);
+        }
+        catch (System.Reflection.TargetInvocationException ex) when (
+            ex.InnerException is InvalidOperationException or COMException)
+        {
+            System.Diagnostics.Debug.WriteLine(
+                $"[NativeWebViewHost] WebView2 resize skipped: {ex.InnerException.Message}");
+
+            if (ex.InnerException is InvalidOperationException)
+            {
+                // Disposed for good. Clearing the references also makes DestroyWindows skip its
+                // Close() call, which would throw the same way.
+                _winController = null;
+                _winWebView = null;
+                _winWebView2Ready = false;
+            }
         }
     }
 

--- a/src/legacy/Bakabase.InsideWorld.Business/Components/Dependency/DependentComponentService.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Components/Dependency/DependentComponentService.cs
@@ -8,11 +8,13 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Bakabase.Abstractions.Components.Configuration;
+using Bakabase.Abstractions.Exceptions;
 using Bakabase.Infrastructures.Components.App;
 using Bakabase.Infrastructures.Components.App.Models.Constants;
 using Bakabase.InsideWorld.Business.Components.Dependency.Abstractions;
 using Bakabase.InsideWorld.Business.Components.Dependency.Abstractions.Models.Constants;
 using Bakabase.InsideWorld.Business.Components.Dependency.Discovery;
+using Bakabase.InsideWorld.Business.Components.Dependency.Exceptions;
 using Bakabase.InsideWorld.Models.Constants;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -51,7 +53,23 @@ namespace Bakabase.InsideWorld.Business.Components.Dependency
 
         protected string GetExecutableWithValidation(string name) => Status == DependentComponentStatus.Installed
             ? Path.Combine(Context.Location!, name)
-            : throw new Exception($"{DisplayName} is not ready");
+            : throw CreateNotReadyException();
+
+        /// <summary>
+        /// The component is not usable yet — either still downloading or never installed. Both are
+        /// things the user resolves from the system settings page, so this is a
+        /// <see cref="DependencyNotInstalledException"/> (an <see cref="IUserActionableException"/>)
+        /// rather than a bare <see cref="Exception"/>: a bare one reads as a crash and ends up in
+        /// the error dashboard.
+        /// </summary>
+        private DependencyNotInstalledException CreateNotReadyException()
+        {
+            var localizer = _globalServiceProvider.GetRequiredService<IDependencyLocalizer>();
+            var message = Status == DependentComponentStatus.Installing
+                ? localizer.Dependency_Installing_Message(DisplayName)
+                : localizer.Dependency_NotInstalled_Message(DisplayName);
+            return new DependencyNotInstalledException(KeyInLocalizer, DisplayName, message);
+        }
 
         /// <summary>
         /// Override this property to declare dependencies that must be installed before this component.
@@ -80,9 +98,12 @@ namespace Bakabase.InsideWorld.Business.Components.Dependency
 
                 if (dependencyService.Status == DependentComponentStatus.Installing)
                 {
+                    // Expected: the user kicked off this install while a prerequisite is still
+                    // downloading. Not a defect — see CreateNotReadyException.
                     var message = dependencyLocalizer.Dependency_Installing_Message(dependencyService.DisplayName);
                     Logger.LogWarning(message);
-                    throw new InvalidOperationException(message);
+                    throw new DependencyNotInstalledException(dependencyService.Id, dependencyService.DisplayName,
+                        message);
                 }
 
                 if (dependencyService.Status != DependentComponentStatus.Installed)

--- a/src/legacy/Bakabase.InsideWorld.Business/Components/Dependency/Exceptions/DependencyNotInstalledException.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Components/Dependency/Exceptions/DependencyNotInstalledException.cs
@@ -1,8 +1,9 @@
 using System;
+using Bakabase.Abstractions.Exceptions;
 
 namespace Bakabase.InsideWorld.Business.Components.Dependency.Exceptions
 {
-    public class DependencyNotInstalledException : Exception
+    public class DependencyNotInstalledException : Exception, IUserActionableException
     {
         public string DependencyName { get; }
         public string DependencyDisplayName { get; }

--- a/src/modules/Bakabase.Modules.ThirdParty/ThirdParties/DLsite/DLsiteClient.cs
+++ b/src/modules/Bakabase.Modules.ThirdParty/ThirdParties/DLsite/DLsiteClient.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using Bakabase.Abstractions.Components.Configuration;
 using Bakabase.Abstractions.Components.Network;
+using Bakabase.Abstractions.Exceptions;
 using Bakabase.Abstractions.Helpers;
 using Bakabase.InsideWorld.Models.Constants;
 using Bakabase.InsideWorld.Models.Models.Dtos;
@@ -18,9 +19,11 @@ using JsonSerializer = System.Text.Json.JsonSerializer;
 namespace Bakabase.Modules.ThirdParty.ThirdParties.DLsite;
 
 /// <summary>
-/// Thrown when DLsite returns 401/403, indicating an authentication issue.
+/// Thrown when DLsite returns 401/403, indicating an authentication issue. The user's cookie
+/// has expired or was pasted wrong — they re-capture it from the DLsite settings page, so this
+/// is an <see cref="IUserActionableException"/> and is kept out of the error dashboard.
 /// </summary>
-public class DLsiteAuthException(string message) : Exception(message);
+public class DLsiteAuthException(string message) : Exception(message), IUserActionableException;
 
 /// <summary>
 /// Thrown when a download URL has expired and needs to be re-resolved.

--- a/src/samples/Bakabase.Demos/Bakabase.Demos.csproj
+++ b/src/samples/Bakabase.Demos/Bakabase.Demos.csproj
@@ -12,9 +12,9 @@
 
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.3.0" />
-        <PackageReference Include="Avalonia.Desktop" Version="11.3.0" />
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.0" />
+        <PackageReference Include="Avalonia" Version="11.3.20" />
+        <PackageReference Include="Avalonia.Desktop" Version="11.3.20" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.20" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/web/src/components/FileExplorer/FileExplorer.tsx
+++ b/src/web/src/components/FileExplorer/FileExplorer.tsx
@@ -175,7 +175,9 @@ const FileExplorer = forwardRef<FileExplorerRef, FileExplorerProps>(
 
       return () => {
         log("Disposing", rootRef);
-        rootRef?.current?.dispose();
+        // Unmount cleanup cannot await, so a rejection here would surface as an unhandled
+        // rejection. Teardown failing changes nothing we can act on.
+        rootRef?.current?.dispose().catch((e) => log("Failed to dispose root entry", e));
         clearTimeout(inputBlurHandlerRef.current);
       };
     }, []);

--- a/src/web/src/components/FileExplorer/FileExplorerEntry.tsx
+++ b/src/web/src/components/FileExplorer/FileExplorerEntry.tsx
@@ -201,7 +201,10 @@ const FileExplorerEntry = (props: FileExplorerEntryProps) => {
   }, []);
 
   useEffect(() => {
-    initialize(entry);
+    // Floating promise — nothing awaits an effect body, so an unhandled rejection here is
+    // reported as a crash. initialize() talks to the backend and touches the DOM after
+    // awaiting, both of which can fail on unmount or while the service is going down.
+    initialize(entry).catch((e) => log("Failed to initialize entry", e));
 
     // Debounced resize handler to prevent excessive re-renders
     const resizeObserver = new ResizeObserver(() => {
@@ -226,7 +229,7 @@ const FileExplorerEntry = (props: FileExplorerEntryProps) => {
 
   useUpdateEffect(() => {
     // log('1234567890');
-    initialize(entry);
+    initialize(entry).catch((e) => log("Failed to initialize entry", e));
   }, [entry]);
 
   const renderFileSystemInfo = useCallback(() => {

--- a/src/web/src/core/models/FileExplorer/RootEntry.ts
+++ b/src/web/src/core/models/FileExplorer/RootEntry.ts
@@ -334,15 +334,26 @@ class RootEntry extends Entry {
         }, 500);
       }
 
-      this.childrenWidth = this._ref?.dom!.parentElement?.clientWidth ?? 0;
+      // Everything above awaits HTTP round-trips, and initialize() itself is called as a
+      // floating promise from a React effect — so the component can unmount while we wait and
+      // `dom` goes null. `_ref?.dom!` asserted that possibility away (IEntryRef.dom is declared
+      // nullable) and threw "Cannot read properties of null (reading 'parentElement')". Guard
+      // it the way recalculateChildrenWidth already does.
+      const dom = this._ref?.dom;
 
-      this._resizeObserver = new ResizeObserver((c) => {
-        const parent = c[0];
+      if (dom) {
+        this.childrenWidth = dom.parentElement?.clientWidth ?? 0;
 
-        log("Size of parent changed", parent);
-        this.recalculateChildrenWidth();
-      });
-      this._resizeObserver.observe(this._ref!.dom!);
+        this._resizeObserver = new ResizeObserver((c) => {
+          const parent = c[0];
+
+          log("Size of parent changed", parent);
+          this.recalculateChildrenWidth();
+        });
+        this._resizeObserver.observe(dom);
+      } else {
+        log("No dom to observe — entry was detached while initializing");
+      }
     }
   }
 
@@ -352,7 +363,15 @@ class RootEntry extends Entry {
     log("Stopping watcher", this, this.path, this._fsWatcher);
     clearInterval(this._fsWatcher);
     clearInterval(this._keepAliveInterval);
-    await BApi.file.stopWatchingChangesInFileProcessorWorkspace();
+    // Best-effort. This releases server-side watcher state, so when the backend is already
+    // gone — app shutting down, service restarting, page unloading — the fetch rejects with
+    // "Failed to fetch" and there is nothing left to release anyway. Swallowing it matters
+    // because every caller is a floating promise, where a rejection reads as a crash.
+    try {
+      await BApi.file.stopWatchingChangesInFileProcessorWorkspace();
+    } catch (e) {
+      log("Failed to stop watching, ignoring", e);
+    }
     useIwFsEntryChangeEventsStore.getState().clear();
     // }
   }


### PR DESCRIPTION
## Summary

All 11 unresolved Sentry issues — 9 in `bakabase-service`, 2 in `bakabase-web` — grouped into 6 root causes. Four were real crashes; two were noise drowning out the rest.

| Root cause | Sentry | Issue |
|---|---|---|
| Dependency not installed / installing threw bare exceptions | `-28`, `-27` | #1223 |
| Expired DLsite cookie reported as an error | `-37`, `-38` | #1224 |
| Sibling directory with a shared name prefix rejected as nested | `-14` | #1225 |
| WebView2 controller disposed while the window was hidden | `-39` | #1226 |
| GDI handle leak per tray icon update | `-29`, `-36`, `-34` | #1227 |
| File explorer teardown races reported as crashes | `WEB-10`, `WEB-1C` | #1229 |

## Closes

Closes #1223
Closes #1224
Closes #1225
Closes #1226
Closes #1227
Closes #1229

## Notable findings

**Tray icon crashes (`-29` / `-36` / `-34`) were a handle leak, not flakiness.** All three threw `Win32Exception: "operation completed successfully"` — Avalonia 11.3.0's `Win32Icon` has no finalizer, so icon GDI handles are never released (AvaloniaUI/Avalonia#15834), and the parameterless `new Win32Exception()` at the failure sites reads a `GetLastError()` that was never set. The throw sites are lines 62 and 68 of `Win32Icon.cs` at the 11.3.0 tag, matching the reported stacks exactly. What fed the leak was ours: `SetTrayIcon` built a fresh `WindowIcon` on every task-manager start/stop transition. Fixed both ends — Avalonia bumped to 11.3.20 (finalizer landed in 11.3.8) and the icons are now cached per state.

**The move/copy failure (`-14`) is a library bug, not a caller bug.** `DirectoryUtils.CopyAsync` tested for a nested destination with a bare `StartsWith` and no separator boundary, so copying `D:\A\Book` into its sibling `D:\A\Book2` (target `D:\A\Book2\Book`) was refused. The existing guard in `MoveEntries` is correct and therefore could not prevent it — which is why the issue kept regressing. Fixed in **anobaka/LazyMortal#1**; **this PR does not include the submodule bump, so `-14` will not clear until that merges and the pointer is updated.** The Bakabase side only extends the same up-front guard to `CopyEntries`, which was missing it entirely.

**Both frontend issues were one defect.** `RootEntry.initialize()` awaits two HTTP round-trips before touching `this._ref?.dom!`, a field declared nullable precisely because it is a React ref — unmounting mid-flight gave the reported `parentElement` of null. Its `_stop()` similarly awaited the watcher-release call bare, which rejects with `Failed to fetch` whenever the backend is already gone. Every caller is a floating promise in an effect, so both surfaced as unhandled rejections.

**Noise filtering is now interface-driven.** `BeforeSend` had a growing chain of `if (ex is …)` special cases, and four earlier issues (#1120, #1122, #1160, #1170) were all this same category. Replaced with an `IUserActionableException` marker interface, walked across the whole `InnerException` chain. The dependency fix sits on `DependentComponentService`, so ffmpeg / lux / LocaleEmulator get it too.

## Testing

- `dotnet build` — 0 errors (`Bakabase.Service` and the `Bakabase` desktop app, including the Avalonia bump).
- `dotnet test src/tests/Bakabase.Tests` — **443 passed, 0 failed, 14 skipped**.
- `yarn build` — clean; `vitest run` — **133 passed**. `tsc --noEmit` reports 568 pre-existing errors project-wide but none in the three files touched here, before or after.
- LazyMortal side: 7 new cross-platform tests for the path helper, all passing.

Not verified here: the three tray icon crashes and the WebView2 one are Windows-only runtime paths that a Linux runner cannot exercise. The Avalonia bump is a patch-level move within 11.3.x, and the desktop app builds clean against it, but it deserves a smoke test on Windows — launch, toggle a task to flip the tray icon, right-click the tray, and reopen the main window from the tray.