### PR TITLE
ci: verify the CDN manifest name Velopack actually emits

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -170,18 +170,30 @@ jobs:
         run: |
           VERSION="${{ needs.prepare.outputs.version }}"
           v=$(echo "$VERSION" | tr '[:upper:]' '[:lower:]')
-          if [[ "$v" == *beta* ]]; then
-            MANIFEST=releases.beta.json
-          elif [[ "$v" == *rc* ]]; then
-            MANIFEST=releases.rc.json
+          # Must mirror the channel logic in _build.yml ("Determine Velopack
+          # channel"): beta/rc pack with `--channel beta`, stable packs with no
+          # `--channel` at all. Without one Velopack falls back to its per-OS
+          # default channel, so a stable build emits releases.win.json /
+          # releases.osx.json -- never an unsuffixed releases.json.
+          if [[ "$v" == *beta* || "$v" == *rc* ]]; then
+            CHANNEL=beta
           else
-            MANIFEST=releases.json
+            CHANNEL=
           fi
-          echo "Verifying manifest: $MANIFEST, expected version: $VERSION"
 
           PLATFORMS=(win-x64 osx-x64 osx-arm64)
           FAILED=()
           for plat in "${PLATFORMS[@]}"; do
+            if [ -n "$CHANNEL" ]; then
+              MANIFEST="releases.${CHANNEL}.json"
+            else
+              case "$plat" in
+                win-*) MANIFEST=releases.win.json ;;
+                osx-*) MANIFEST=releases.osx.json ;;
+                *) echo "::error::No default Velopack channel known for platform $plat"; exit 1 ;;
+              esac
+            fi
+            echo "[$plat] verifying manifest: $MANIFEST, expected version: $VERSION"
             URL="https://cdn-public.anobaka.com/app/bakabase/releases/${plat}/${MANIFEST}"
             OK=0
             for i in $(seq 1 6); do


### PR DESCRIPTION
The `cdn-refresh / Verify CDN serves new version` step failed on the v2.3.0 release ([run 32681660235](https://github.com/anobaka/Bakabase/actions/runs/32681660235)) with a 404 on all three platforms. The deploy itself was fine — 2.3.0 was on the CDN the whole time; only the check looked for a file that is never produced.

## Root cause

The step derived the manifest filename from the version string:

```
*beta* -> releases.beta.json
*rc*   -> releases.rc.json
else   -> releases.json          # 2.3.0 landed here
```

But the filename is decided by the vpk channel in `_build.yml`: beta/rc pack with `--channel beta`, stable packs with **no** `--channel` at all. Without one Velopack falls back to its per-OS default channel, so a stable build emits `releases.win.json` / `releases.osx.json`. An unsuffixed `releases.json` never exists.

`releases.rc.json` was dead code for the same reason — `_build.yml` maps rc to the `beta` channel.

## Why it only surfaced now

The verify step was added 2026-05-01 (`ac4b36e2`). The previous stable release, v2.2.0, shipped 2026-04-10 — before Velopack was even wired in (`0e1c9f35`, 2026-04-13). Every deploy in between was a `-beta` build, where both sides agree on `releases.beta.json`. v2.3.0 is the first stable release the step has ever seen.

## Blast radius

CI-only. `AppUpdater.cs:53` uses `ExplicitChannel = null` and resolves the same per-OS default as vpk, so shipped clients were always requesting the file that exists. No user-facing update was ever broken.

## Fix

Derive the manifest name per platform from the same channel logic as `_build.yml`, with a comment tying the two together so they do not drift again.

## Verification

Extracted the patched step and ran it against the live CDN:

| version | resolved manifest | result |
|---|---|---|
| `2.3.0` (the failing case) | `releases.win.json` / `releases.osx.json` | passes |
| `2.3.0-beta.296` | `releases.beta.json` | passes (no regression) |
| `2.4.0-rc.1` | `releases.beta.json` (was the dead `releases.rc.json`) | fails on version mismatch, as expected |
| `9.9.9` | — | still exits 1 |

`deploy.yml` still parses as YAML.

Closes #1230

🤖 Generated with [Claude Code](https://claude.com/claude-code)