### PR TITLE
ci: auto-deploy a beta on every push to main again

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -126,19 +126,22 @@ its `Closes #N` line to the commit for the change.
 
 ### Skip CI for docs / `.claude` changes
 
-`deploy.yml` ("Build and Deploy") auto-runs **only on push to `release/v*`**
-— pushing a release branch is a deliberate publish. `main` / `debug-actions`
-are **not** auto-deployed; they deploy only via manual `workflow_dispatch`, so
-merging several PRs into `main` no longer fires a release per merge (batch
-them, then dispatch when ready). `ci.yml` runs only on PRs and is enforced as
-a required status check via branch protection, so the merge commit is never
-re-tested and deploy is no longer gated on CI.
+`deploy.yml` ("Build and Deploy") auto-runs on **every push to `main`** and on
+push to `release/v*`. A `main` push publishes a beta; a `release/v*` push
+publishes the corresponding stable. The version is never decided by the
+workflow — `version.json` owns it and the pipeline reads it through nbgv, so
+each `main` commit gets its own beta number. `debug-actions` is **not**
+auto-deployed; deploy it via manual `workflow_dispatch`. `ci.yml` runs only on
+PRs and is enforced as a required status check via branch protection, so the
+merge commit is never re-tested and deploy is not gated on CI.
 
-`[skip ci]` therefore only matters on the auto-deploy branch: add it to a
-commit you push to `release/v*` that touches **only** documentation,
-`.claude/**`, or other non-code files, to skip that release build. It does
-**not** affect `Closes #N` issue auto-closing. On `main` nothing auto-deploys,
-so the directive is moot there.
+Because `main` auto-deploys, add **`[skip ci]`** to a commit that touches
+**only** documentation, `.claude/**`, or other non-code files, so it doesn't
+burn a full build + OSS deploy + GitHub release. It does **not** affect
+`Closes #N` issue auto-closing.
+
+Do **not** skip CI for `.github/**` changes — CI/CD config edits should run
+the pipeline so the change itself gets validated.
 
 ```
 docs: 更新 GitHub issue 管理工作流程 [skip ci]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,16 +1,22 @@
 name: Build and Deploy
 
 on:
-  # Auto-deploy only on the release branches — pushing a release/v* branch is a
-  # deliberate publish. main / debug-actions are NOT auto-deployed: merging
-  # several PRs into main shouldn't fire a release per merge, so batch them and
-  # publish via the manual workflow_dispatch below when ready.
-  # (CI no longer gates this; branch protection requires CI to pass before a PR
-  # can merge, so whatever lands here was already validated on the PR.)
+  # Auto-deploy every push to main and to the release branches: a main push
+  # publishes a beta, a release/v* push publishes the corresponding stable.
+  # Nothing here inspects the branch to decide a version — version.json owns
+  # that and the whole pipeline reads it through nbgv (main is currently
+  # "2.4.0-beta.{height}", so each commit gets its own beta number).
+  #
+  # CI does not gate this: ci.yml runs on pull_request only and is a required
+  # status check via branch protection, so whatever lands on main was already
+  # validated on its PR. (Deploy used to chain off CI via `workflow_run`; that
+  # cannot work now that CI deliberately skips merge commits.)
+  #
+  # debug-actions is intentionally left out — deploy it via workflow_dispatch.
   push:
-    branches: [ 'release/v*' ]
-  # Manual trigger: deploy any ref on demand — main betas, debug-actions, or a
-  # re-deploy without a new commit. Pick the branch when dispatching.
+    branches: [ main, 'release/v*' ]
+  # Manual trigger: deploy any ref on demand — debug-actions, or a re-deploy
+  # without a new commit. Pick the branch when dispatching.
   workflow_dispatch:
 
 # Don't cancel an in-progress deploy — OSS uploads + GitHub releases shouldn't


### PR DESCRIPTION
Restores the pre-`dec6f5b6` behaviour: **every push to `main` builds and publishes a beta**.

## Why

`dec6f5b6` (Closes #1203) took `main` off auto-deploy so that a batch of merges would not fire a release each, moving it to manual `workflow_dispatch`. In practice the dispatch just gets forgotten — nothing has been published since 2026-06-12, so `2.4.0-beta` was never built at all and the CDN beta channel still serves `2.3.0-beta.296`.

## What changed

```diff
   push:
-    branches: [ 'release/v*' ]
+    branches: [ main, 'release/v*' ]
```

Notably **not** a revert. The original mechanism was `workflow_run` chained off CI, which cannot work any more: `ci.yml` now triggers on `pull_request` only, so a push to `main` produces no CI run for `workflow_run` to observe. A plain `push` trigger is the right shape now — branch protection already requires CI to pass before a PR can merge, so anything landing on `main` was validated on its PR.

`debug-actions` stays dispatch-only; auto-publishing releases from a debug branch is not wanted. Say the word if you want it included.

## Version handling

Unchanged, and deliberately so — the workflow never decides a version. `version.json` owns it and the pipeline reads it via nbgv:

```
$ nbgv get-version -f json
"CloudBuildNumber": "2.4.0-beta.0"     # main: "2.4.0-beta.{height}", height=1, offset=-1
```

The prepare job then trims the trailing `.0` for the first beta, so the sequence runs `2.4.0-beta`, `2.4.0-beta.1`, `2.4.0-beta.2`, … with no workflow involvement. No branch-specific version logic exists anywhere in `prepare` / `_build` / `_deploy` / `_release`.

## Heads-up

Merging this PR is itself a push to `main`, so it will **immediately publish `2.4.0-beta.1`** — a real release: OSS upload, GitHub release, CDN refresh, and beta users get an update prompt. That is the intended behaviour, just worth knowing the first one fires on merge.

It also brings back what #1203 was avoiding: N merges in a row means N full builds and N beta releases (serialized — `cancel-in-progress: false`). That is the accepted trade-off here. `[skip ci]` on docs-only commits is the escape hatch, and `.claude/CLAUDE.md` is updated to say so again.

## Verification

- `deploy.yml` and `ci.yml` both parse; triggers are `{push: [main, release/v*], workflow_dispatch}` and `{pull_request, workflow_dispatch}` respectively — no overlap, no double-fire.
- `nbgv get-version` confirms the version comes from `version.json` as above.

Closes #1232

🤖 Generated with [Claude Code](https://claude.com/claude-code)