### PR TITLE
Clean up stale tray icons on startup and graceful shutdown

### DIFF
--- a/src/abstractions/Bakabase.Abstractions/Components/Gui/ITrayIconController.cs
+++ b/src/abstractions/Bakabase.Abstractions/Components/Gui/ITrayIconController.cs
@@ -3,4 +3,13 @@ namespace Bakabase.Abstractions.Components.Gui;
 public interface ITrayIconController
 {
     void SetTrayIcon(bool isRunning);
+
+    /// <summary>
+    /// Registers / unregisters the tray icon with the shell. Hide it on any code path that is
+    /// about to end the process without an orderly GUI shutdown — most notably the Velopack
+    /// update-restart, which ends in <c>Environment.Exit</c>. Skipping that leaves Windows
+    /// painting a dead icon until the user happens to hover over it.
+    /// Idempotent and must never throw.
+    /// </summary>
+    void SetTrayIconVisible(bool visible);
 }

--- a/src/apps/Bakabase.Service/Controllers/UpdaterController.cs
+++ b/src/apps/Bakabase.Service/Controllers/UpdaterController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Bakabase.Abstractions.Components.Gui;
 using Bakabase.Infrastructures.Components.App.Upgrade;
 using Bakabase.Infrastructures.Components.App.Upgrade.Abstractions;
 using Bootstrap.Components.Miscellaneous.ResponseBuilders;
@@ -13,10 +14,12 @@ namespace Bakabase.Service.Controllers
     public class UpdaterController : Controller
     {
         private readonly AppUpdater _appUpdater;
+        private readonly ITrayIconController? _trayIconController;
 
-        public UpdaterController(AppUpdater appUpdater)
+        public UpdaterController(AppUpdater appUpdater, ITrayIconController? trayIconController = null)
         {
             _appUpdater = appUpdater;
+            _trayIconController = trayIconController;
         }
 
         [HttpGet("app/new-version")]
@@ -45,7 +48,23 @@ namespace Bakabase.Service.Controllers
         [SwaggerOperation(OperationId = "RestartAndUpdateApp")]
         public async Task<BaseResponse> RestartAndUpdateApp()
         {
-            await _appUpdater.ApplyUpdatesAndRestart();
+            // ApplyUpdatesAndRestart hands over to Velopack and ends in Environment.Exit, so
+            // the GUI never gets an orderly shutdown. Drop the tray icon here, while the app
+            // is still healthy, or Windows keeps painting it next to the icon of the freshly
+            // restarted instance until the user hovers over it.
+            _trayIconController?.SetTrayIconVisible(false);
+            try
+            {
+                await _appUpdater.ApplyUpdatesAndRestart();
+            }
+            catch
+            {
+                // The call never returns on success, so getting here means we are staying
+                // alive after all — put the icon back.
+                _trayIconController?.SetTrayIconVisible(true);
+                throw;
+            }
+
             return BaseResponseBuilder.Ok;
         }
     }

--- a/src/apps/Bakabase/App.axaml.cs
+++ b/src/apps/Bakabase/App.axaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
@@ -57,6 +58,22 @@ public partial class App : Application
             // Wire up tray events now that Host is available
             AppTrayIcon.Clicked += (_, _) => _guiAdapter.Show();
 
+            // desktop.Exit below covers the graceful exits only. Anything that ends the
+            // process without unwinding Avalonia — Environment.Exit from Velopack's
+            // ApplyUpdatesAndRestart, a fatal-error bail-out, Ctrl+C on a console run —
+            // would otherwise leave the icon registered with Explorer until the user
+            // happens to hover it. ProcessExit fires for all of those.
+            AppDomain.CurrentDomain.ProcessExit += (_, _) => SetTrayIconVisible(false);
+
+            // A previous instance that was hard-killed (VS "Stop Debugging", Task Manager,
+            // a crash) ran none of the above and left its icon behind. Nothing in *that*
+            // process can fix it after the fact, so the next launch cleans up instead.
+            _ = System.Threading.Tasks.Task.Run(async () =>
+            {
+                await System.Threading.Tasks.Task.Delay(TimeSpan.FromSeconds(2));
+                TrayIconGhostSweeper.Sweep();
+            });
+
             var openItem = AppTrayIcon.Menu!.Items.OfType<NativeMenuItem>().First(i => i.Header == "Open");
             var exitItem = AppTrayIcon.Menu!.Items.OfType<NativeMenuItem>().First(i => i.Header == "Exit");
             openItem.Click += (_, _) => _guiAdapter.Show();
@@ -66,9 +83,36 @@ public partial class App : Application
 
             desktop.Exit += (_, _) =>
             {
-                AppTrayIcon.IsVisible = false;
+                SetTrayIconVisible(false);
                 Host?.Dispose();
             };
+        }
+    }
+
+    /// <summary>
+    /// Registers / unregisters the tray icon with the shell (Shell_NotifyIcon NIM_ADD /
+    /// NIM_DELETE on Windows). Idempotent, never throws, and safe to call from any thread —
+    /// most callers are exit paths, where an exception would be worse than a leftover icon.
+    /// </summary>
+    public void SetTrayIconVisible(bool visible)
+    {
+        try
+        {
+            if (Dispatcher.UIThread.CheckAccess())
+            {
+                AppTrayIcon.IsVisible = visible;
+            }
+            else
+            {
+                // Bounded wait: on the ProcessExit path the UI thread is still pumping, but
+                // if it ever isn't we must not stall the process on its way out.
+                Dispatcher.UIThread.Invoke(() => AppTrayIcon.IsVisible = visible,
+                    DispatcherPriority.Send, CancellationToken.None, TimeSpan.FromSeconds(2));
+            }
+        }
+        catch
+        {
+            // Already torn down / dispatcher gone — nothing left to clean up.
         }
     }
 

--- a/src/apps/Bakabase/Components/AvaloniaGuiAdapter.cs
+++ b/src/apps/Bakabase/Components/AvaloniaGuiAdapter.cs
@@ -90,6 +90,8 @@ public class AvaloniaGuiAdapter : GuiAdapter, ITrayIconController
         });
     }
 
+    public void SetTrayIconVisible(bool visible) => _app.SetTrayIconVisible(visible);
+
     [GuiContextInterceptor]
     public override void ShowFatalErrorWindow(string message, string title = "Fatal Error")
     {

--- a/src/apps/Bakabase/Components/TrayIconGhostSweeper.cs
+++ b/src/apps/Bakabase/Components/TrayIconGhostSweeper.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Bakabase.Components;
+
+/// <summary>
+/// Removes "ghost" tray icons — entries the Windows notification area still paints for a
+/// process that is already gone.
+///
+/// A tray icon is registered with <c>Shell_NotifyIcon(NIM_ADD)</c> against an owner window
+/// and is only unregistered when the owner calls <c>NIM_DELETE</c>. When a process dies
+/// without getting the chance to do that — Visual Studio's "Stop Debugging" (a plain
+/// TerminateProcess: no finalizers, no ProcessExit, no user code at all), Task Manager
+/// "End task", a hard crash — Explorer keeps the stale entry until it next re-validates it.
+/// It only re-validates the icons the mouse passes over, which is exactly why the leftover
+/// icon disappears the moment you hover it.
+///
+/// Everything that runs inside our own process (see <c>App.HideTrayIcon</c>) cannot help
+/// there, because nothing of ours runs. So we do the re-validation for the user instead:
+/// once at startup we synthesize the mouse movement Explorer is waiting for, which makes it
+/// drop every dead entry — ours from a previous run, and any other app's while we're at it.
+/// </summary>
+internal static class TrayIconGhostSweeper
+{
+    /// <summary>Top-level shell windows that host notification-area toolbars.</summary>
+    private static readonly string[] TrayHostClasses =
+    [
+        // Taskbar (promoted icons).
+        "Shell_TrayWnd",
+        // Overflow flyout ("hidden icons"), Windows 10 / early Windows 11.
+        "NotifyIconOverflowWindow",
+        // Overflow flyout, Windows 11 22H2+. Hosts a XAML island; on builds that still keep a
+        // classic toolbar inside it we can sweep it, otherwise the search simply finds nothing.
+        "TopLevelWindowForOverflowXamlIsland"
+    ];
+
+    private const string ToolbarClassName = "ToolbarWindow32";
+
+    /// <summary>Tray buttons are ~16-24px wide; 8px steps hit every one of them.</summary>
+    private const int ProbeStep = 8;
+
+    /// <summary>Bounds the work per toolbar so an absurd client rect can't spam Explorer.</summary>
+    private const int MaxProbesPerToolbar = 512;
+
+    /// <summary>
+    /// Best-effort, no-op on non-Windows. Safe to call at any time: only entries whose owner
+    /// window no longer exists are dropped, so live icons (ours included) are never touched.
+    /// </summary>
+    public static void Sweep()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        try
+        {
+            foreach (var toolbar in FindNotificationToolbars())
+            {
+                ProbeToolbar(toolbar);
+            }
+        }
+        catch
+        {
+            // Purely cosmetic housekeeping against undocumented shell internals — a change in
+            // Explorer's window layout must never be able to take the app down.
+        }
+    }
+
+    private static List<IntPtr> FindNotificationToolbars()
+    {
+        var toolbars = new List<IntPtr>();
+        var className = new StringBuilder(256);
+
+        // EnumChildWindows already walks the whole descendant tree, so a flat scan per host
+        // window is enough regardless of how deeply the toolbar is nested.
+        var collect = new EnumWindowsProc((hwnd, _) =>
+        {
+            className.Clear();
+            if (GetClassNameW(hwnd, className, className.Capacity) > 0 &&
+                string.Equals(className.ToString(), ToolbarClassName, StringComparison.Ordinal))
+            {
+                toolbars.Add(hwnd);
+            }
+
+            return true;
+        });
+
+        foreach (var hostClass in TrayHostClasses)
+        {
+            var host = FindWindowW(hostClass, null);
+            if (host != IntPtr.Zero)
+            {
+                EnumChildWindows(host, collect, IntPtr.Zero);
+            }
+        }
+
+        GC.KeepAlive(collect);
+        return toolbars;
+    }
+
+    private static void ProbeToolbar(IntPtr toolbar)
+    {
+        if (!GetClientRect(toolbar, out var rect))
+        {
+            return;
+        }
+
+        var width = rect.Right - rect.Left;
+        var height = rect.Bottom - rect.Top;
+        if (width <= 0 || height <= 0)
+        {
+            return;
+        }
+
+        var probes = 0;
+        for (var y = ProbeStep / 2; y < height; y += ProbeStep)
+        {
+            for (var x = ProbeStep / 2; x < width; x += ProbeStep)
+            {
+                if (++probes > MaxProbesPerToolbar)
+                {
+                    return;
+                }
+
+                // SendMessageTimeout rather than SendMessage: Explorer is another process and
+                // we must not block startup on it if it is busy or hung.
+                SendMessageTimeoutW(toolbar, WM_MOUSEMOVE, IntPtr.Zero, MakeLParam(x, y),
+                    SMTO_ABORTIFHUNG, ProbeTimeoutMs, out _);
+            }
+        }
+    }
+
+    private static IntPtr MakeLParam(int x, int y) => (IntPtr)((y << 16) | (x & 0xFFFF));
+
+    private const uint WM_MOUSEMOVE = 0x0200;
+    private const uint SMTO_ABORTIFHUNG = 0x0002;
+    private const uint ProbeTimeoutMs = 20;
+
+    private delegate bool EnumWindowsProc(IntPtr hwnd, IntPtr lParam);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern IntPtr FindWindowW(string? lpClassName, string? lpWindowName);
+
+    [DllImport("user32.dll")]
+    private static extern bool EnumChildWindows(IntPtr hwndParent, EnumWindowsProc lpEnumFunc, IntPtr lParam);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetClassNameW(IntPtr hwnd, StringBuilder lpClassName, int nMaxCount);
+
+    [DllImport("user32.dll")]
+    private static extern bool GetClientRect(IntPtr hwnd, out RECT lpRect);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern IntPtr SendMessageTimeoutW(IntPtr hwnd, uint msg, IntPtr wParam, IntPtr lParam,
+        uint flags, uint timeout, out IntPtr result);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct RECT
+    {
+        public int Left, Top, Right, Bottom;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes Windows notification area ("tray") icons left behind when the application terminates without an orderly shutdown. This addresses two scenarios:

1. **Hard kills** (VS "Stop Debugging", Task Manager, crashes): The previous instance leaves its icon registered with Explorer. On next launch, we now sweep and clean it up.
2. **Velopack update-restart**: `Environment.Exit` bypasses normal Avalonia shutdown, leaving the icon painted until the user hovers over it. We now hide it before the restart.

## Changes

- **New `TrayIconGhostSweeper` component** (`src/apps/Bakabase/Components/TrayIconGhostSweeper.cs`):
  - Scans Windows notification-area toolbars (taskbar, overflow flyout) for stale tray icons
  - Synthesizes mouse movement over toolbar regions to trigger Explorer's re-validation
  - Safely drops entries whose owner windows no longer exist
  - Runs on a 2-second delay at startup to allow Explorer to stabilize
  - Best-effort, no-op on non-Windows platforms

- **Enhanced `App.axaml.cs`**:
  - Added `SetTrayIconVisible(bool)` method: idempotent, thread-safe wrapper for hiding/showing the tray icon
  - Wired `ProcessExit` event to hide the icon on any process termination (including `Environment.Exit`)
  - Scheduled `TrayIconGhostSweeper.Sweep()` on startup to clean up icons from previous hard kills
  - Updated `desktop.Exit` handler to use the new method

- **Updated `ITrayIconController` interface**:
  - Added `SetTrayIconVisible(bool)` contract for GUI adapters to implement

- **Updated `AvaloniaGuiAdapter`**:
  - Implemented `SetTrayIconVisible(bool)` to delegate to the app

- **Updated `UpdaterController`**:
  - Calls `SetTrayIconVisible(false)` before `ApplyUpdatesAndRestart()` to hide the icon before Velopack takes over
  - Restores visibility if the restart fails and the app stays alive

## Implementation Details

- The sweeper uses P/Invoke to enumerate Windows shell windows and their child toolbars, then sends `WM_MOUSEMOVE` messages with a timeout to avoid blocking on a hung Explorer
- `SetTrayIconVisible` handles cross-thread calls with a bounded wait (2 seconds) to prevent stalling process exit
- All cleanup paths are wrapped in try-catch to ensure a stale icon never crashes the app

https://claude.ai/code/session_013cjWZVz6shNNKT24Aa6gjq